### PR TITLE
Feature chunked

### DIFF
--- a/Includes.hpp
+++ b/Includes.hpp
@@ -1,3 +1,4 @@
+
 #pragma once
 
 // Standard C++ Library
@@ -35,6 +36,17 @@
 #define MAX_EVENTS 64
 #define BUFFER_SIZE 4096
 #define KEEP_ALIVE_TIMEOUT 15
+
+//UTF-8 byte masks and prefixes
+#define ASCII_MASK 0x80
+#define TWO_BYTE_MASK 0xE0
+#define TWO_BYTE_PREFIX 0xC0
+#define THREE_BYTE_MASK 0xF0
+#define THREE_BYTE_PREFIX 0xE0
+#define FOUR_BYTE_MASK 0xF8
+#define FOUR_BYTE_PREFIX 0xF0
+#define CONTINUATION_MASK 0xC0
+#define CONTINUATION_PREFIX 0x80
 
 // ANSI Color Codes for Terminal Output
 #define RESET   "\033[0m"       // Reset all attributes

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ FILES			= main.cpp \
 				  Utils.cpp \
 				  ServerManager/Request.cpp \
 				  ServerManager/ServerManager.cpp \
+				  ServerManager/ServerManagerChunked.cpp \
 				  ServerManager/ServerManagerClient.cpp \
 				  ServerManager/ServerManagerLoop.cpp \
 				  ServerManager/ServerManagerRequest.cpp \

--- a/Response/ResponseBuilder.hpp
+++ b/Response/ResponseBuilder.hpp
@@ -13,6 +13,8 @@
 class ResponseBuilder{
 	public:
 		std::string returnResponse(const Request& request, const ConfigResolved& resolvedConfig, bool keepAlive);
+		std::string returnGenericErrorResponse(int statusCode, const Request& request, const ConfigResolved& resolvedConfig);
+		std::string returnRedirectErrorResponse(int statusCode, const Request& request, const ConfigResolved& resolvedConfig);
 	private:
 		int _statusCode;
 		std::string _statusLine;
@@ -31,9 +33,6 @@ class ResponseBuilder{
 
 		int getStatusCode();
 		int determineStatusCode(const std::string& request, const ConfigResolved& resolvedConfig);
-
-		 std::string returnGenericErrorResponse(int statusCode, const Request& request, const ConfigResolved& resolvedConfig);
-		 std::string returnRedirectErrorResponse(int statusCode, const Request& request, const ConfigResolved& resolvedConfig);
 
 		std::string getStatusCodeString();
 		std::string getStatusLine();

--- a/Response/ResponseBuilder.hpp
+++ b/Response/ResponseBuilder.hpp
@@ -40,10 +40,6 @@ class ResponseBuilder{
 //		status code determination
 		int determineStatusCode(const std::string& request, const ConfigResolved& resolvedConfig);
 
-// 		Error response helpers
-		std::string returnGenericErrorResponse(int statusCode, const Request& request, const ConfigResolved& resolvedConfig);
-		std::string returnRedirectErrorResponse(int statusCode, const Request& request, const ConfigResolved& resolvedConfig);
-
 // 		Helper functions for response building
 		std::string getStatusCodeString();
 		std::string getStatusLine();

--- a/ServerManager/Request.cpp
+++ b/ServerManager/Request.cpp
@@ -17,7 +17,10 @@ static bool decodeChunkedBody(const std::string &rawBody, std::string &decoded) 
 		std::string sizeLine = rawBody.substr(pos, lineEnd - pos);
 		// Parse chunk size (hex)
 		size_t chunkSize = 0;
-		std::istringstream iss(sizeLine);
+		// ignore chunk extensions
+		size_t semi = sizeLine.find(';');
+		std::string sizeStr = sizeLine.substr(0, semi);
+		std::istringstream iss(sizeStr);
 		iss >> std::hex >> chunkSize;
 		if (iss.fail())
 			return false;

--- a/ServerManager/Request.cpp
+++ b/ServerManager/Request.cpp
@@ -103,6 +103,15 @@ bool Request::parseRequestLine(const std::string &head, std::istringstream &head
 	if (!line.empty() && line[line.size() - 1] == '\r')
 		line.erase(line.size() - 1);
 
+	// Enforce exactly one space between tokens in the request line
+	size_t firstSpace = line.find(' ');
+	size_t secondSpace = line.find(' ', firstSpace + 1);
+	// There must be exactly two spaces, and no consecutive spaces
+	if (firstSpace == std::string::npos || secondSpace == std::string::npos ||
+		line.find(' ', secondSpace + 1) != std::string::npos ||
+		secondSpace == firstSpace + 1)
+		return (printLog("🚨 Invalid request line spacing", RED), _status = 400, false);
+
 	// Split the request-line into its three whitespace-delimited tokens.
 	std::istringstream requestLine(line);
 	std::string methodToken;
@@ -185,6 +194,17 @@ bool Request::parseHeaders(std::istringstream &headStream)
 		// Extract the raw key and raw value around the colon.
 		std::string rawKey = line.substr(0, colonPos);
 		std::string rawValue = line.substr(colonPos + 1);
+		// Reject header values containing any tab character (edge test requirement)
+		for (size_t i = 0; i < rawValue.size(); ++i) {
+			if (rawValue[i] == '\t')
+				return (printLog("🚨 Tab in header value", RED), _status = 400, false);
+		}
+/*			// Reject header keys containing any non-visible ASCII (only allow 33–126)
+			for (size_t i = 0; i < rawKey.size(); ++i) {
+				unsigned char c = rawKey[i];
+				if (c < 33 || c > 126)
+					return (printLog("🚨 Invalid character in header key", RED), _status = 400, false);
+			}*/
 		std::string key = toLower(trimSpaces(rawKey));
 		std::string value = trimSpaces(rawValue);
 		if (key.empty())
@@ -285,7 +305,7 @@ bool Request::parseRequest(const std::string &rawRequest, size_t contentLength) 
 
 	// Split at the blank line:
 	//   head — everything before \r\n\r\n (request-line + headers)
-	//   body — everything after  \r\n\r\n (may be empty for GET/DELETE)
+	//   body — everything after  \r\n\r\n
 	std::string head = rawRequest.substr(0, headerEnd);
 	std::string body = rawRequest.substr(headerEnd + 4);
 	std::istringstream headStream;

--- a/ServerManager/Request.cpp
+++ b/ServerManager/Request.cpp
@@ -1,6 +1,46 @@
 #include "Request.hpp"
 
 /**
+ * @brief Decodes a chunked Transfer-Encoding body according to RFC 7230 Section 3.3.1.
+ * @param rawBody The raw chunked body string.
+ * @param decoded Output string for the decoded body.
+ * @return true if decoding succeeds, false if malformed.
+ */
+static bool decodeChunkedBody(const std::string &rawBody, std::string &decoded) {
+	decoded.clear();
+	size_t pos = 0;
+	while (pos < rawBody.size()) {
+		// Find chunk size line
+		size_t lineEnd = rawBody.find("\r\n", pos);
+		if (lineEnd == std::string::npos)
+			return false;
+		std::string sizeLine = rawBody.substr(pos, lineEnd - pos);
+		// Parse chunk size (hex)
+		size_t chunkSize = 0;
+		std::istringstream iss(sizeLine);
+		iss >> std::hex >> chunkSize;
+		if (iss.fail())
+			return false;
+		pos = lineEnd + 2;
+		if (chunkSize == 0) {
+			// End of chunks; next should be CRLF
+			// Optionally, handle trailers here
+			return true;
+		}
+		// Ensure enough bytes for chunk
+		if (pos + chunkSize > rawBody.size())
+			return false;
+		decoded.append(rawBody.substr(pos, chunkSize));
+		pos += chunkSize;
+		// Expect CRLF after chunk
+		if (rawBody.substr(pos, 2) != "\r\n")
+			return false;
+		pos += 2;
+	}
+	return false;
+}
+
+/**
  * @brief Checks if a string is valid UTF-8 and contains only printable characters.
  * @param s Input string to validate.
  * @return true if valid, false otherwise.
@@ -229,8 +269,10 @@ bool Request::validateAndCacheHostHeader()
 {
 	// HTTP/1.1 clients MUST send a Host header
 	// HTTP/1.0 clients are not required to
-	if (_version == "HTTP/1.1" && _headers.find("host") == _headers.end())
-		return (printLog("🚨 Missing Host header", RED), _status = 400, false);
+	if (_version == "HTTP/1.1") {
+		if (_headers.find("host") == _headers.end())
+			return (printLog("🚨 Missing Host header", RED), _status = 400, false);
+	}
 
 	// Cache the Host value in _host
 	std::map<std::string, std::string>::const_iterator hostIt = _headers.find("host");
@@ -267,17 +309,21 @@ bool Request::parseAndValidateBody(const std::string &body, size_t contentLength
 	if (_method == POST && contentLengthIt == _headers.end() && !_isChunked)
 		return (printLog("⚠️ Content-Length header missing", RED), _status = 411, false);
 
-	if (contentLengthIt != _headers.end() || _isChunked)
-	{
+	if (_isChunked) {
+		std::string decoded;
+		if (!decodeChunkedBody(body, decoded))
+			return (printLog("🚨 Malformed chunked body", RED), _status = 400, false);
+		_body = decoded;
+	} else if (contentLengthIt != _headers.end()) {
 		// If buffer is not enough bytes yet the request is incomplete.
 		if (body.size() < contentLength)
 			return (printLog("🚨 Incomplete request body", RED), _status = 400, false);
 		// Copy exactly contentLength bytes to avoid reading into the next
 		_body = body.substr(0, contentLength);
-	}
-	else
+	} else {
 		// No Content-Length header and non-POST method.
 		_body = "";
+	}
 
 /*	// POST bodies must declare their MIME type.
 	if (_method == POST && _headers.find("content-type") == _headers.end())

--- a/ServerManager/Request.cpp
+++ b/ServerManager/Request.cpp
@@ -1,49 +1,6 @@
 #include "Request.hpp"
 
 /**
- * @brief Decodes a chunked Transfer-Encoding body according to RFC 7230 Section 3.3.1.
- * @param rawBody The raw chunked body string.
- * @param decoded Output string for the decoded body.
- * @return true if decoding succeeds, false if malformed.
- */
-static bool decodeChunkedBody(const std::string &rawBody, std::string &decoded) {
-	decoded.clear();
-	size_t pos = 0;
-	while (pos < rawBody.size()) {
-		// Find chunk size line
-		size_t lineEnd = rawBody.find("\r\n", pos);
-		if (lineEnd == std::string::npos)
-			return false;
-		std::string sizeLine = rawBody.substr(pos, lineEnd - pos);
-		// Parse chunk size (hex)
-		size_t chunkSize = 0;
-		// ignore chunk extensions
-		size_t semi = sizeLine.find(';');
-		std::string sizeStr = sizeLine.substr(0, semi);
-		std::istringstream iss(sizeStr);
-		iss >> std::hex >> chunkSize;
-		if (iss.fail())
-			return false;
-		pos = lineEnd + 2;
-		if (chunkSize == 0) {
-			// End of chunks; next should be CRLF
-			// Optionally, handle trailers here
-			return true;
-		}
-		// Ensure enough bytes for chunk
-		if (pos + chunkSize > rawBody.size())
-			return false;
-		decoded.append(rawBody.substr(pos, chunkSize));
-		pos += chunkSize;
-		// Expect CRLF after chunk
-		if (rawBody.substr(pos, 2) != "\r\n")
-			return false;
-		pos += 2;
-	}
-	return false;
-}
-
-/**
  * @brief Checks if a string is valid UTF-8 and contains only printable characters.
  * @param s Input string to validate.
  * @return true if valid, false otherwise.
@@ -313,10 +270,11 @@ bool Request::parseAndValidateBody(const std::string &body, size_t contentLength
 		return (printLog("⚠️ Content-Length header missing", RED), _status = 411, false);
 
 	if (_isChunked) {
-		std::string decoded;
+/* 		std::string decoded;
 		if (!decodeChunkedBody(body, decoded))
-			return (printLog("🚨 Malformed chunked body", RED), _status = 400, false);
-		_body = decoded;
+			return (printLog("🚨 Malformed chunked body", RED), _status = 400, false); 
+		_body = decoded;*/
+		_body = body;
 	} else if (contentLengthIt != _headers.end()) {
 		// If buffer is not enough bytes yet the request is incomplete.
 		if (body.size() < contentLength)
@@ -328,10 +286,7 @@ bool Request::parseAndValidateBody(const std::string &body, size_t contentLength
 		_body = "";
 	}
 
-/*	// POST bodies must declare their MIME type.
-	if (_method == POST && _headers.find("content-type") == _headers.end())
-		return (printLog("⚠️ Content-Type header missing", RED), _status = 400, false);
-*/  //For both HTTP/1.0 and HTTP/1.1, Content-Type is recommended but not required for POST requests. Your server should accept POST requests without
+  //For both HTTP/1.0 and HTTP/1.1, Content-Type is recommended but not required for POST requests. Your server should accept POST requests without
 	return true;
 }
 
@@ -375,7 +330,8 @@ bool Request::parseRequest(const std::string &rawRequest, size_t contentLength) 
 	// Step 5 — Set _isChunked if Transfer-Encoding: chunked is present.
 	cacheTransferEncodingFlags();
 	// Step 6 — Validate Content-Length / Content-Type and copy body into _body.
-	return parseAndValidateBody(body, contentLength);
+		bool bodyOk = parseAndValidateBody(body, contentLength);
+		return bodyOk;
 }
 
 /**

--- a/ServerManager/Request.cpp
+++ b/ServerManager/Request.cpp
@@ -109,12 +109,20 @@ bool Request::parseRequestLine(const std::string &head, std::istringstream &head
 	if (!(requestLine >> methodToken >> target >> _version))
 		return (printLog("🚨 Malformed request line", RED), _status = 400, false);
 
+	if (target.size() > 2048)
+		return (printLog("🚨 URI too long", RED), _status = 414, false);
 	// HTTP/1.x allows exactly three tokens on the request-line.
 	// A fourth token means the client sent garbage.
 	std::string trailingToken;
 	if (requestLine >> trailingToken)
 		return (printLog("🚨 Invalid request line format", RED), _status = 400, false);
 
+	// Validate method token for whitespace or non-ASCII
+	for (size_t i = 0; i < methodToken.size(); ++i) {
+		unsigned char c = methodToken[i];
+		if (std::isspace(static_cast<unsigned char>(c)) || c < 65 || c > 90) // 'A'-'Z'
+			return (printLog("🚨 Invalid whitespace or non-uppercase in method", RED), _status = 400, false);
+	}
 	// Validate the method string and store the corresponding enum value.
 	if (!parseMethodToken(methodToken))
 		return false;
@@ -156,6 +164,7 @@ bool Request::parseTargetAndQuery(const std::string &target)
 bool Request::parseHeaders(std::istringstream &headStream)
 {
 	std::string line;
+	int hostCount = 0;
 	while (std::getline(headStream, line)) {
 		// Strip the trailing '\r' left by CRLF line endings.
 		if (!line.empty() && line[line.size() - 1] == '\r')
@@ -181,6 +190,11 @@ bool Request::parseHeaders(std::istringstream &headStream)
 		if (key.empty())
 			return (printLog("🚨 Empty header key", RED), _status = 400, false);
 
+		if (key == "host") {
+			hostCount++;
+			if (hostCount > 1)
+				return (printLog("🚨 Multiple Host headers", RED), _status = 400, false);
+		}
 		_headers[key] = value;
 	}
 

--- a/ServerManager/Request.cpp
+++ b/ServerManager/Request.cpp
@@ -1,5 +1,41 @@
 #include "Request.hpp"
 
+/**
+ * @brief Checks if a string is valid UTF-8 and contains only printable characters.
+ * @param s Input string to validate.
+ * @return true if valid, false otherwise.
+ */
+static bool isValidUtf8AndPrintable(const std::string &s) {
+		size_t len = s.size();
+		size_t i = 0;
+		while (i < len) {
+			unsigned char c = s[i];
+			// Use std::isprint for ASCII, allow tab
+			if (c < ASCII_MASK) {
+				if (!std::isprint(c) && c != '\t') return false;
+				i++;
+				continue;
+			}
+			size_t remaining = len - i;
+			if ((c & TWO_BYTE_MASK) == TWO_BYTE_PREFIX) {
+				if (remaining < 2 || (static_cast<unsigned char>(s[i+1]) & CONTINUATION_MASK) != CONTINUATION_PREFIX)
+					return false;
+				i += 2;
+			} else if ((c & THREE_BYTE_MASK) == THREE_BYTE_PREFIX) {
+				if (remaining < 3 || (static_cast<unsigned char>(s[i+1]) & CONTINUATION_MASK) != CONTINUATION_PREFIX || (static_cast<unsigned char>(s[i+2]) & CONTINUATION_MASK) != CONTINUATION_PREFIX)
+					return false;
+				i += 3;
+			} else if ((c & FOUR_BYTE_MASK) == FOUR_BYTE_PREFIX) {
+				if (remaining < 4 || (static_cast<unsigned char>(s[i+1]) & CONTINUATION_MASK) != CONTINUATION_PREFIX || (static_cast<unsigned char>(s[i+2]) & CONTINUATION_MASK) != CONTINUATION_PREFIX || (static_cast<unsigned char>(s[i+3]) & CONTINUATION_MASK) != CONTINUATION_PREFIX)
+					return false;
+				i += 4;
+			} else {
+				return false;
+			}
+		}
+		return true;
+}
+
 Request::Request()
 	: _status(200), _isRedirect(false), _isAutoindex(false),
 	  _method(GET), _autoIndexPath(""), _path(""), _version(""),
@@ -120,13 +156,16 @@ bool Request::parseTargetAndQuery(const std::string &target)
 bool Request::parseHeaders(std::istringstream &headStream)
 {
 	std::string line;
-	while (std::getline(headStream, line))
-	{
+	while (std::getline(headStream, line)) {
 		// Strip the trailing '\r' left by CRLF line endings.
 		if (!line.empty() && line[line.size() - 1] == '\r')
 			line.erase(line.size() - 1);
 		if (line.empty())
 			continue;
+
+		// Validate UTF-8 and printable characters in the header line
+		if (!isValidUtf8AndPrintable(line))
+			return (printLog("🚨 Invalid UTF-8 or non-printable in header", RED), _status = 400, false);
 
 		// The first ':' separates the field name from the field value.
 		// colonPos == 0 means the name is empty, which is invalid.
@@ -173,7 +212,6 @@ bool Request::validateAndCacheHostHeader()
 void Request::cacheTransferEncodingFlags()
 {
 	// Transfer-Encoding: chunked means the body arrives in size-prefixed chunks
-	// instead of a single payload delimited by Content-Length.
 	// We cache the flag here; actual chunk parsing is not yet implemented.
 	std::map<std::string, std::string>::const_iterator transferEncodingIt = _headers.find("transfer-encoding");
 	if (transferEncodingIt != _headers.end())
@@ -190,12 +228,12 @@ bool Request::parseAndValidateBody(const std::string &body, size_t contentLength
 {
 	std::map<std::string, std::string>::const_iterator contentLengthIt = _headers.find("content-length");
 
-	// A POST request must declare how long its body is.
-	// Without Content-Length (and without chunked encoding) we cannot know where the body ends, so we reject with 411 Length Required.
-	if (_method == POST && contentLengthIt == _headers.end())
+	// A POST request must declare body length either via Content-Length,
+	// or via Transfer-Encoding: chunked already decoded by transport.
+	if (_method == POST && contentLengthIt == _headers.end() && !_isChunked)
 		return (printLog("⚠️ Content-Length header missing", RED), _status = 411, false);
 
-	if (contentLengthIt != _headers.end())
+	if (contentLengthIt != _headers.end() || _isChunked)
 	{
 		// If buffer is not enough bytes yet the request is incomplete.
 		if (body.size() < contentLength)
@@ -207,10 +245,10 @@ bool Request::parseAndValidateBody(const std::string &body, size_t contentLength
 		// No Content-Length header and non-POST method.
 		_body = "";
 
-	// POST bodies must declare their MIME type.
+/*	// POST bodies must declare their MIME type.
 	if (_method == POST && _headers.find("content-type") == _headers.end())
 		return (printLog("⚠️ Content-Type header missing", RED), _status = 400, false);
-
+*/  //For both HTTP/1.0 and HTTP/1.1, Content-Type is recommended but not required for POST requests. Your server should accept POST requests without
 	return true;
 }
 

--- a/ServerManager/Request.hpp
+++ b/ServerManager/Request.hpp
@@ -13,10 +13,14 @@ class Request {
 	public :
 		Request();
 		~Request();
-
+		
 		bool parseRequest(const std::string &rawRequest, size_t knownContentLength);
 		void parseQueryString(const std::string &query, std::map<std::string, std::string> &queryParams);
-
+		
+		// setter
+		void setVersion(const std::string &version) { _version = version; }
+		void setStatus(const int &status) { _status = status; }
+		
 		//getters
 		int getStatus() const { return _status; };
 		Method getMethod() const { return _method; };

--- a/ServerManager/ServerManager.hpp
+++ b/ServerManager/ServerManager.hpp
@@ -59,7 +59,7 @@ class ServerManager {
 		void readClientRequest(ClientSession &client, size_t maxUploadSize);
 		void parseClientRequest(ClientSession &client, ServerConfig &server);
 		void processClientRequest(ClientSession &client, Request &request, ServerConfig &server);
-		void sendClientResponse(ClientSession &client);
+		void sendClientResponse(ClientSession &client, ServerConfig &server);
 		void handleReadyEvent(const epoll_event &event);
 		void cleanupSockets();
 		void cleanupClients();

--- a/ServerManager/ServerManager.hpp
+++ b/ServerManager/ServerManager.hpp
@@ -67,7 +67,7 @@ class ServerManager {
 		void closeClientSocket(ClientSession &client);
 		void closeIdleClients(time_t now);
 		void decodeChunked(ClientSession &client, size_t maxUploadSize);
-		bool parseTransferEncodingHeader(const std::string &headersLower, bool &hasTransferEncoding, bool &isChunkedOnly);
+		int parseTransferEncodingHeader(const std::string &headersLower, bool &hasTransferEncoding, bool &isChunkedOnly);
 
 	public :
 		ServerManager(char **argv);

--- a/ServerManager/ServerManager.hpp
+++ b/ServerManager/ServerManager.hpp
@@ -49,24 +49,25 @@ class ServerManager {
 		std::map<int, int> _listenerFdToServer;
 		std::map<int, int> _clientFdToServer;
 
-		void parseConfigServers();
-		void setupListeningSockets();
 		int buildListeningSocket(const ServerConfig &server, int port, const std::string &serverInfo);
+		bool acceptClientConnection(int fd, int serverIndex);
+		void setupListeningSockets();
 		void addListenerToEpoll(int fd, int serverIndex);
 		void addClientToEpoll(ClientSession &client);
 		void modClientEpoll(const ClientSession &client, uint32_t events);
-		bool acceptClientConnection(int fd, int serverIndex);
-		void cleanupSockets();
-		void closeClient(int serverIndex, int fd);
-		void cleanupClients();
-		void closeClientSocket(ClientSession &client);
 		void handleClientRequest(ClientSession &client, ServerConfig &server);
 		void readClientRequest(ClientSession &client, size_t maxUploadSize);
 		void parseClientRequest(ClientSession &client, ServerConfig &server);
 		void processClientRequest(ClientSession &client, Request &request, ServerConfig &server);
 		void sendClientResponse(ClientSession &client);
-		void closeIdleClients(time_t now);
 		void handleReadyEvent(const epoll_event &event);
+		void cleanupSockets();
+		void cleanupClients();
+		void closeClient(int serverIndex, int fd);
+		void closeClientSocket(ClientSession &client);
+		void closeIdleClients(time_t now);
+		void decodeChunked(ClientSession &client, size_t maxUploadSize);
+		bool parseTransferEncodingHeader(const std::string &headersLower, bool &hasTransferEncoding, bool &isChunkedOnly);
 
 	public :
 		ServerManager(char **argv);

--- a/ServerManager/ServerManagerChunked.cpp
+++ b/ServerManager/ServerManagerChunked.cpp
@@ -5,9 +5,9 @@
  * @param headersLower Lowercased header lines (without request line).
  * @param hasTransferEncoding Output flag indicating presence of Transfer-Encoding header.
  * @param isChunkedOnly Output flag indicating only supported TE values are present.
- * @return true when header syntax is acceptable, false on malformed/unsupported TE.
+ * @return the error code.
  */
-bool ServerManager::parseTransferEncodingHeader(const std::string &headersLower, bool &hasTransferEncoding, bool &isChunkedOnly)
+int ServerManager::parseTransferEncodingHeader(const std::string &headersLower, bool &hasTransferEncoding, bool &isChunkedOnly)
 {
 	hasTransferEncoding = false;
 	isChunkedOnly = false;
@@ -27,14 +27,14 @@ bool ServerManager::parseTransferEncodingHeader(const std::string &headersLower,
 		{
 			// if has more then 1 transfer-encoding, reject
 			if (hasTransferEncoding)
-				return 0;
+				return 1; //Malformed: multiple TE
 			hasTransferEncoding = true;
 
 			// get the value part after "transfer-encoding:"
 			std::string value = headersLower.substr(lineStart + headerName.size(), lineEnd - (lineStart + headerName.size()));
 			value = trimSpaces(value);
 			if (value.empty())
-				return 0;
+				return 1; //Malformed, empty value
 
 			// parse comma-separated tokens in the value
 			bool seenChunked = false;
@@ -48,13 +48,13 @@ bool ServerManager::parseTransferEncodingHeader(const std::string &headersLower,
 				std::string token = value.substr(tokenStart, tokenEnd - tokenStart);
 				token = trimSpaces(token);
 				if (token.empty())
-					return 0;
+					return 1; //Malformed, empty token
 				// only chunked,reject any other value
 				if (token != "chunked")
-					return 0;
+					return 2; //Unsuported TE
 				// reject if has more then 1 chunked
 				if (seenChunked)
-					return 0;
+					return 1; //Malformed, duplicated
 				seenChunked = true;
 
 				// if has no more commas, break
@@ -65,7 +65,7 @@ bool ServerManager::parseTransferEncodingHeader(const std::string &headersLower,
 
 			// if no chunk, reject
 			if (!seenChunked)
-				return 0;
+				return 1; //Malformed, its not  chunked
 			isChunkedOnly = true;
 		}
 
@@ -77,7 +77,7 @@ bool ServerManager::parseTransferEncodingHeader(const std::string &headersLower,
 	}
 
 	// is valid
-	return 1;
+	return 0;
 }
 
 void ServerManager::decodeChunked(ClientSession &client, size_t maxUploadSize)
@@ -113,7 +113,15 @@ void ServerManager::decodeChunked(ClientSession &client, size_t maxUploadSize)
 		}
 
 		size_t chunkSize = 0;
-		// Parse chunk size as hexadecimal.
+		std::istringstream iss(sizeLine);
+		iss >> std::hex >> chunkSize;
+		if (iss.fail()) {
+			client.status = 400;
+			client.keepAlive = false;
+			client.state = WRITING;
+			return;
+		}
+		/* // Parse chunk size as hexadecimal.
 		for (size_t i = 0; i < sizeLine.size(); ++i)
 		{
 			unsigned char ch = static_cast<unsigned char>(sizeLine[i]);
@@ -141,18 +149,18 @@ void ServerManager::decodeChunked(ClientSession &client, size_t maxUploadSize)
 				return;
 			}
 			chunkSize = chunkSize * 16 + static_cast<size_t>(value);
-		}
+		} */
 
 		cursor = lineEnd + 2; // Move cursor past chunk size line.
 
 		if (chunkSize == 0)
 		{
 			// Last chunk: look for trailer terminator.
-			size_t trailerEnd = body.find("\r\n\r\n", cursor);
+			size_t trailerEnd = body.find("\r\n", cursor);
 			if (trailerEnd == std::string::npos)
 				return; // Wait for complete trailers.
 
-			size_t consumedBodyBytes = trailerEnd + 4;
+			size_t consumedBodyBytes = trailerEnd + 2;
 			std::string remaining = body.substr(consumedBodyBytes); // Any pipelined requests after chunked body.
 			std::string headersPart = client.readBuffer.substr(0, bodyStart); // Preserve headers.
 			client.contentLength = decodedBody.size(); // Set decoded body size.

--- a/ServerManager/ServerManagerChunked.cpp
+++ b/ServerManager/ServerManagerChunked.cpp
@@ -1,0 +1,190 @@
+#include "ServerManager.hpp"
+
+/**
+ * @brief Validates Transfer-Encoding lines and reports whether they are exactly "chunked".
+ * @param headersLower Lowercased header lines (without request line).
+ * @param hasTransferEncoding Output flag indicating presence of Transfer-Encoding header.
+ * @param isChunkedOnly Output flag indicating only supported TE values are present.
+ * @return true when header syntax is acceptable, false on malformed/unsupported TE.
+ */
+bool ServerManager::parseTransferEncodingHeader(const std::string &headersLower, bool &hasTransferEncoding, bool &isChunkedOnly)
+{
+	hasTransferEncoding = false;
+	isChunkedOnly = false;
+	const std::string headerName = "transfer-encoding:";
+
+	// loop through each header line.
+	for (size_t lineStart = 0; lineStart < headersLower.size(); )
+	{
+		// find the end of the current header line.
+		size_t lineEnd = headersLower.find("\r\n", lineStart);
+		if (lineEnd == std::string::npos)
+			lineEnd = headersLower.size();
+
+		// if this line starts with "transfer-encoding:"
+		if (lineEnd > lineStart
+			&& headersLower.compare(lineStart, headerName.size(), headerName) == 0)
+		{
+			// if has more then 1 transfer-encoding, reject
+			if (hasTransferEncoding)
+				return 0;
+			hasTransferEncoding = true;
+
+			// get the value part after "transfer-encoding:"
+			std::string value = headersLower.substr(lineStart + headerName.size(), lineEnd - (lineStart + headerName.size()));
+			value = trimSpaces(value);
+			if (value.empty())
+				return 0;
+
+			// parse comma-separated tokens in the value
+			bool seenChunked = false;
+			size_t tokenStart = 0;
+			while (tokenStart <= value.size())
+			{
+				// find the next comma
+				size_t commaPos = value.find(',', tokenStart);
+				size_t tokenEnd = (commaPos == std::string::npos) ? value.size() : commaPos;
+				// get and trim the token
+				std::string token = value.substr(tokenStart, tokenEnd - tokenStart);
+				token = trimSpaces(token);
+				if (token.empty())
+					return 0;
+				// only chunked,reject any other value
+				if (token != "chunked")
+					return 0;
+				// reject if has more then 1 chunked
+				if (seenChunked)
+					return 0;
+				seenChunked = true;
+
+				// if has no more commas, break
+				if (commaPos == std::string::npos)
+					break;
+				tokenStart = commaPos + 1;
+			}
+
+			// if no chunk, reject
+			if (!seenChunked)
+				return 0;
+			isChunkedOnly = true;
+		}
+
+		// if is the last line, break
+		if (lineEnd == headersLower.size())
+			break;
+		// start of the next line
+		lineStart = lineEnd + 2;
+	}
+
+	// is valid
+	return 1;
+}
+
+void ServerManager::decodeChunked(ClientSession &client, size_t maxUploadSize)
+{
+	client.state = READING;
+
+	size_t headerEnd = client.readBuffer.find("\r\n\r\n");
+	if (headerEnd == std::string::npos)
+		return; // Wait for complete headers.
+
+	size_t bodyStart = headerEnd + 4; // Body starts after header terminator.
+	std::string body = client.readBuffer.substr(bodyStart); // Extract body bytes.
+	std::string decodedBody; // Will hold the decoded chunked payload.
+	size_t cursor = 0; // Cursor tracks position in body.
+
+	for (;;)
+	{
+		size_t lineEnd = body.find("\r\n", cursor);
+		if (lineEnd == std::string::npos)
+			return; // Wait for complete chunk size line.
+
+		std::string sizeLine = body.substr(cursor, lineEnd - cursor); // Get chunk size line.
+		size_t extensionPos = sizeLine.find(';');
+		if (extensionPos != std::string::npos)
+			sizeLine = sizeLine.substr(0, extensionPos); // Ignore chunk extensions.
+		sizeLine = trimSpaces(sizeLine); // Remove whitespace.
+		if (sizeLine.empty())
+		{
+			client.status = 400; // Empty chunk size line is invalid.
+			client.keepAlive = false;
+			client.state = WRITING;
+			return;
+		}
+
+		size_t chunkSize = 0;
+		// Parse chunk size as hexadecimal.
+		for (size_t i = 0; i < sizeLine.size(); ++i)
+		{
+			unsigned char ch = static_cast<unsigned char>(sizeLine[i]);
+			int value;
+			if (ch >= '0' && ch <= '9')
+				value = ch - '0';
+			else if (ch >= 'a' && ch <= 'f')
+				value = 10 + (ch - 'a');
+			else if (ch >= 'A' && ch <= 'F')
+				value = 10 + (ch - 'A');
+			else
+			{
+				client.status = 400; // Invalid hex digit.
+				client.keepAlive = false;
+				client.state = WRITING;
+				return;
+			}
+
+			// Prevent overflow.
+			if (chunkSize > (std::numeric_limits<size_t>::max() - static_cast<size_t>(value)) / 16)
+			{
+				client.status = 400;
+				client.keepAlive = false;
+				client.state = WRITING;
+				return;
+			}
+			chunkSize = chunkSize * 16 + static_cast<size_t>(value);
+		}
+
+		cursor = lineEnd + 2; // Move cursor past chunk size line.
+
+		if (chunkSize == 0)
+		{
+			// Last chunk: look for trailer terminator.
+			size_t trailerEnd = body.find("\r\n\r\n", cursor);
+			if (trailerEnd == std::string::npos)
+				return; // Wait for complete trailers.
+
+			size_t consumedBodyBytes = trailerEnd + 4;
+			std::string remaining = body.substr(consumedBodyBytes); // Any pipelined requests after chunked body.
+			std::string headersPart = client.readBuffer.substr(0, bodyStart); // Preserve headers.
+			client.contentLength = decodedBody.size(); // Set decoded body size.
+			client.readBuffer = headersPart + decodedBody + remaining; // Replace buffer with decoded body.
+			client.state = PROCESSING; // Ready to process request.
+			return;
+		}
+
+		// Wait for full chunk data and trailing CRLF.
+		if (cursor + chunkSize + 2 > body.size())
+			return;
+
+		// Enforce max upload size.
+		if (decodedBody.size() > maxUploadSize - chunkSize)
+		{
+			client.status = 413; // Payload Too Large.
+			client.keepAlive = false;
+			client.state = WRITING;
+			return;
+		}
+
+		decodedBody.append(body, cursor, chunkSize); // Append chunk data.
+		cursor += chunkSize; // Move cursor past chunk data.
+
+		// Validate chunk terminator.
+		if (body.compare(cursor, 2, "\r\n") != 0)
+		{
+			client.status = 400; // Missing chunk CRLF.
+			client.keepAlive = false;
+			client.state = WRITING;
+			return;
+		}
+		cursor += 2; // Move cursor past chunk CRLF.
+	}
+}

--- a/ServerManager/ServerManagerChunked.cpp
+++ b/ServerManager/ServerManagerChunked.cpp
@@ -121,35 +121,6 @@ void ServerManager::decodeChunked(ClientSession &client, size_t maxUploadSize)
 			client.state = WRITING;
 			return;
 		}
-		/* // Parse chunk size as hexadecimal.
-		for (size_t i = 0; i < sizeLine.size(); ++i)
-		{
-			unsigned char ch = static_cast<unsigned char>(sizeLine[i]);
-			int value;
-			if (ch >= '0' && ch <= '9')
-				value = ch - '0';
-			else if (ch >= 'a' && ch <= 'f')
-				value = 10 + (ch - 'a');
-			else if (ch >= 'A' && ch <= 'F')
-				value = 10 + (ch - 'A');
-			else
-			{
-				client.status = 400; // Invalid hex digit.
-				client.keepAlive = false;
-				client.state = WRITING;
-				return;
-			}
-
-			// Prevent overflow.
-			if (chunkSize > (std::numeric_limits<size_t>::max() - static_cast<size_t>(value)) / 16)
-			{
-				client.status = 400;
-				client.keepAlive = false;
-				client.state = WRITING;
-				return;
-			}
-			chunkSize = chunkSize * 16 + static_cast<size_t>(value);
-		} */
 
 		cursor = lineEnd + 2; // Move cursor past chunk size line.
 

--- a/ServerManager/ServerManagerRequest.cpp
+++ b/ServerManager/ServerManagerRequest.cpp
@@ -3,57 +3,6 @@
 #include "../Response/ResponseBuilder.hpp"
 
 /**
- * @brief Maps status code to reason phrase for fallback/plain responses.
- */
-static std::string getReasonPhrase(int statusCode)
-{
-	switch (statusCode)
-	{
-		case 200: return "OK";
-		case 400: return "Bad Request";
-		case 431: return "Request Header Fields Too Large";
-		case 403: return "Forbidden";
-		case 404: return "Not Found";
-		case 405: return "Method Not Allowed";
-		case 411: return "Length Required";
-		case 413: return "Payload Too Large";
-		case 414: return "Request-URI Too Long";
-		case 500: return "Internal Server Error";
-		case 501: return "Not Implemented";
-		case 505: return "HTTP Version Not Supported";
-		default: return "Error";
-	}
-}
-
-/**
- * @brief Builds a minimal HTTP response when no specialized responder is used.
- * @param statusCode HTTP status code.
- * @param keepAlive Whether to keep connection open.
- * @param explicitBody Optional response body override.
- * @param version HTTP version.
- * @return Serialized HTTP response text.
- */
-static std::string buildDefaultResponse(int status, bool keepAlive, const std::string &body, const std::string &version)
-{
-	//Person 3 ownership: replace this fallback with the final Response engine serializer.
-	// If no explicit body was prepared by higher-level logic, use a tiny
-	// fallback body derived from the status text so the client still gets
-	// a valid human-readable response.
-	std::string responseBody = body;
-	if (responseBody.empty())
-		responseBody = getReasonPhrase(status) + "\n";
-	std::ostringstream oss;
-	oss << version << " " << status << " " << getReasonPhrase(status) << "\r\n";
-	oss << "Content-Type: text/plain\r\n";
-	oss << "Content-Length: " << responseBody.size() << "\r\n";
-	oss << "Connection: " << (keepAlive ? "keep-alive" : "close") << "\r\n";
-	oss << "\r\n";
-	oss << responseBody;
-	return oss.str();
-}
-
-
-/**
  * @brief Advances one client state-machine step based on current state.
  * @param client Client session.
  * @param server Owning server configuration (used for body-size and future routing hooks).
@@ -88,7 +37,7 @@ void ServerManager::handleClientRequest(ClientSession &client, ServerConfig &ser
 				modClientEpoll(client, EPOLLOUT);
 			break;
 		case WRITING:
-			sendClientResponse(client);
+			sendClientResponse(client, server);
 			break;
 		case IDLE:
 		default:
@@ -125,7 +74,13 @@ void ServerManager::parseClientRequest(ClientSession &client, ServerConfig &serv
 			client.readBuffer.clear();
 			client.contentLength = 0;
 			client.version = "HTTP/1.1";
-			client.writeBuffer = buildDefaultResponse(431, false, "", client.version);
+			// Use ResponseBuilder for error response
+			Request errorRequest;
+			errorRequest.setStatus(431);
+			errorRequest.setVersion(client.version);
+			ConfigResolved config(errorRequest, server);
+			ResponseBuilder rb;
+			client.writeBuffer = rb.returnGenericErrorResponse(431, errorRequest, config);
 			modClientEpoll(client, EPOLLOUT); // Ensure response is sent
 			return;
 		}
@@ -158,6 +113,10 @@ void ServerManager::parseClientRequest(ClientSession &client, ServerConfig &serv
 		client.keepAlive = false;
 		client.state = WRITING;
 		remainingBuffer.clear();
+		// Use ResponseBuilder for error response
+		ConfigResolved config(request, server);
+		ResponseBuilder rb;
+		client.writeBuffer = rb.returnGenericErrorResponse(request.getStatus(), request, config);
 	}
 	else
 	{
@@ -218,7 +177,7 @@ void ServerManager::processClientRequest(ClientSession &client, Request &request
  * @brief Sends response bytes and handles keep-alive reset/close decisions.
  * @param client Client session.
  */
-void ServerManager::sendClientResponse(ClientSession &client)
+void ServerManager::sendClientResponse(ClientSession &client, ServerConfig &server)
 {
 	if (client.fd < 0)
 	{
@@ -226,10 +185,15 @@ void ServerManager::sendClientResponse(ClientSession &client)
 		return;
 	}
 
-	if (client.writeBuffer.empty())
-		// Person 3 hook: build Response object + headers/body here, then
-		// serialize to HTTP text (status line, Content-Length, Connection).
-		client.writeBuffer = buildDefaultResponse(client.status, client.keepAlive, client.responseStr, client.version);
+	if (client.writeBuffer.empty()) {
+		// Use ResponseBuilder for error responses if writeBuffer is empty
+		Request errorRequest;
+		errorRequest.setStatus(client.status);
+		errorRequest.setVersion(client.version);
+		ConfigResolved config(errorRequest, server);
+		ResponseBuilder rb;
+		client.writeBuffer = rb.returnGenericErrorResponse(client.status, errorRequest, config);
+	}
 
 	// send() starts at writeBuffer + totalSent so partially sent responses can resume.
 	ssize_t sentBytes = send(client.fd, client.writeBuffer.c_str() + client.totalSent,

--- a/ServerManager/ServerManagerRequest.cpp
+++ b/ServerManager/ServerManagerRequest.cpp
@@ -103,30 +103,29 @@ void ServerManager::parseClientRequest(ClientSession &client, ServerConfig &serv
 
 	client.request = Request();
 	Request &request = client.request;
-	if (!request.parseRequest(requestBuffer, client.contentLength))
-	{
-		client.writeBuffer.clear();
-		client.path = "";
-		client.method = NONE;
-		client.status = request.getStatus();
-		printLog("⚠️ Malformed HTTP request handled", YEL);
-		client.keepAlive = false;
-		client.state = WRITING;
-		remainingBuffer.clear();
-		// Use ResponseBuilder for error response
-		ConfigResolved config(request, server);
-		ResponseBuilder rb;
-		client.writeBuffer = rb.returnGenericErrorResponse(request.getStatus(), request, config);
-	}
-	else
-	{
-		// Person 2 hook: receive parsed Request + current ServerConfig and decide
-		// routing/config result (best location, method validation, effective path, status).
-		// For now processClientRequest() copies the parsed metadata into transport fields.
-		processClientRequest(client, request, server);
-		if (!client.keepAlive)
-			remainingBuffer.clear();
-	}
+			if (!request.parseRequest(requestBuffer, client.contentLength))
+			{
+				client.writeBuffer.clear();
+				client.path = "";
+				client.method = NONE;
+				client.status = request.getStatus();
+				printLog("⚠️ Malformed HTTP request handled", YEL);
+				client.keepAlive = false;
+				client.state = WRITING;
+				remainingBuffer.clear();
+				// Use ResponseBuilder for error response
+				ConfigResolved config(request, server);
+				ResponseBuilder rb;
+				client.writeBuffer = rb.returnGenericErrorResponse(request.getStatus(), request, config);
+			} else
+			{
+				// Person 2 hook: receive parsed Request + current ServerConfig and decide
+				// routing/config result (best location, method validation, effective path, status).
+				// For now processClientRequest() copies the parsed metadata into transport fields.
+				processClientRequest(client, request, server);
+				if (!client.keepAlive)
+					remainingBuffer.clear();
+			}
 
 	// Keep only leftover bytes that belong to future requests.
 	client.readBuffer = remainingBuffer;

--- a/ServerManager/ServerManagerRequest.cpp
+++ b/ServerManager/ServerManagerRequest.cpp
@@ -106,9 +106,25 @@ void ServerManager::parseClientRequest(ClientSession &client, ServerConfig &serv
 	size_t requestSize = std::string::npos;
 	// Find end of headers for the current request frame.
 	size_t headerEnd = client.readBuffer.find("\r\n\r\n");
+	// Header size limit (RFC 6585, 431): 8KB is common, adjust as needed
+	const size_t MAX_HEADER_SIZE = 8192;
 	if (headerEnd != std::string::npos)
 	{
 		size_t headerSize = headerEnd + 4;
+		if (headerSize > MAX_HEADER_SIZE) {
+			client.writeBuffer.clear();
+			client.path = "";
+			client.method = NONE;
+			client.status = 431;
+			printLog("🚨 Oversized headers: 431 Request Header Fields Too Large", RED);
+			client.keepAlive = false;
+			client.state = WRITING;
+			client.readBuffer.clear();
+			client.contentLength = 0;
+			client.version = "HTTP/1.1";
+			modClientEpoll(client, EPOLLOUT); // Ensure response is sent
+			return;
+		}
 		// Guard bounds before computing total request bytes.
 		if (headerSize <= client.readBuffer.size()
 			&& client.contentLength <= client.readBuffer.size() - headerSize)

--- a/ServerManager/ServerManagerRequest.cpp
+++ b/ServerManager/ServerManagerRequest.cpp
@@ -15,6 +15,7 @@ static std::string getReasonPhrase(int statusCode)
 		case 405: return "Method Not Allowed";
 		case 411: return "Length Required";
 		case 413: return "Payload Too Large";
+		case 414: return "Request-URI Too Long";
 		case 500: return "Internal Server Error";
 		case 501: return "Not Implemented";
 		case 505: return "HTTP Version Not Supported";

--- a/ServerManager/ServerManagerRequest.cpp
+++ b/ServerManager/ServerManagerRequest.cpp
@@ -123,6 +123,7 @@ void ServerManager::parseClientRequest(ClientSession &client, ServerConfig &serv
 			client.readBuffer.clear();
 			client.contentLength = 0;
 			client.version = "HTTP/1.1";
+			client.writeBuffer = buildDefaultResponse(431, false, "", client.version);
 			modClientEpoll(client, EPOLLOUT); // Ensure response is sent
 			return;
 		}

--- a/ServerManager/ServerManagerRequestRead.cpp
+++ b/ServerManager/ServerManagerRequestRead.cpp
@@ -221,7 +221,15 @@ void ServerManager::readClientRequest(ClientSession &client, size_t maxUploadSiz
 
 	bool hasTransferEncoding = false;
 	bool isChunkedOnly = false;
-	if (!parseTransferEncodingHeader(headersLower, hasTransferEncoding, isChunkedOnly))
+	int teResult = parseTransferEncodingHeader(headersLower, hasTransferEncoding, isChunkedOnly);
+	if (teResult == 1) // Malformed
+	{
+		client.status = 400;
+		client.keepAlive = false;
+		client.state = WRITING;
+		return;
+	}
+	if (teResult == 2) // Unsupported
 	{
 		client.status = 501;
 		client.keepAlive = false;

--- a/ServerManager/ServerManagerRequestRead.cpp
+++ b/ServerManager/ServerManagerRequestRead.cpp
@@ -261,15 +261,15 @@ void ServerManager::readClientRequest(ClientSession &client, size_t maxUploadSiz
 		return;
 	}
 
-	       // Always parse Content-Length from headers after receiving them.
-	       if (!parseContentLengthValue(headersLower, client.contentLength))
-	       {
-		       printLog("🚨 Invalid Content-Length", RED);
-		       client.status = 400;
-		       client.keepAlive = false;
-		       client.state = WRITING;
-		       return;
-	       }
+			// Always parse Content-Length from headers after receiving them.
+			if (!parseContentLengthValue(headersLower, client.contentLength))
+			{
+				printLog("🚨 Invalid Content-Length", RED);
+				client.status = 400;
+				client.keepAlive = false;
+				client.state = WRITING;
+				return;
+			}
 
 	// If declared body is larger than configured upload limit, fail early.
 	if (client.contentLength > maxUploadSize)

--- a/ServerManager/ServerManagerRequestRead.cpp
+++ b/ServerManager/ServerManagerRequestRead.cpp
@@ -31,7 +31,7 @@ static bool hasHeaderToken(const std::string &headersLower, const std::string &h
 		// Move to the next line (skip "\r\n").
 		lineStart = lineEnd + 2;
 	}
-	return false;
+	return 0;
 }
 
 /**
@@ -73,7 +73,7 @@ static bool parseContentLengthValue(const std::string &headersLower, size_t &out
 				// Second Content-Length header found: reject request.
 				// Multiple Content-Length lines are ambiguous and can enable
 				// request-smuggling desync between intermediaries and origin server.
-				return false;
+				return 0;
 			}
 		}
 
@@ -98,7 +98,7 @@ static bool parseContentLengthValue(const std::string &headersLower, size_t &out
 
 	// Empty value after trimming is invalid (e.g. "content-length:   ").
 	if (end <= start)
-		return false;
+		return 0;
 
 	// Isolate the raw Content-Length token to parse.
 	std::string valueStr = headersLower.substr(start, end - start);
@@ -111,15 +111,15 @@ static bool parseContentLengthValue(const std::string &headersLower, size_t &out
 	catch (const std::exception &)
 	{
 		// Convert parsing exceptions into this function's bool error contract.
-		return false;
+		return 0;
 	}
 
 	if (value < 0)
-		return false;
+		return 0;
 
 	// Ensure the parsed value can fit in size_t before casting.
 	if (static_cast<unsigned long>(value) > std::numeric_limits<size_t>::max())
-		return false;
+		return 0;
 
 	// Store validated Content-Length.
 	outContentLength = static_cast<size_t>(value);
@@ -221,47 +221,49 @@ void ServerManager::readClientRequest(ClientSession &client, size_t maxUploadSiz
 	size_t headerStart = requestLineEnd + 2;
 	std::string headersLower = toLower(client.readBuffer.substr(headerStart, headerEnd - headerStart));
 
-	// Transfer-Encoding support is not implemented.
-	// chunked, gzip, deflate is rejected with 501.
-	//
-	// When chunked decoding is done
-	//
-	//   if (hasHeaderToken(headersLower, "transfer-encoding:", "chunked"))
-	//   {
-	//       /* decode the chunked body into client.readBuffer */
-	//       client.state = PROCESSING;
-	//       return;
-	//   }
-	//   /* reject every OTHER TE value */
-	//   if (headersLower.find("transfer-encoding:") != std::string::npos)
-	//   {
-	//       client.status = 501;
-	//       client.keepAlive = false;
-	//       client.state = WRITING;
-	//       return;
-	//   }
-	// ALGUMA COISA ASSIM
-	if (headersLower.find("transfer-encoding:") != std::string::npos)
+	bool hasTransferEncoding = false;
+	bool isChunkedOnly = false;
+	if (!parseTransferEncodingHeader(headersLower, hasTransferEncoding, isChunkedOnly))
 	{
 		client.status = 501;
 		client.keepAlive = false;
 		client.state = WRITING;
 		return;
 	}
-	//WHEN CHUNKED IS FIXED CHANGE TO COMMENT PART
-
-	if (client.contentLength == 0)
+	//if has transfer encoding and content-length, refuse, safe way. client made bad request or smt
+	if (hasTransferEncoding && headersLower.find("content-length:") != std::string::npos)
 	{
-		// Parse Content-Length once from headers and validate numeric format.
-		if (!parseContentLengthValue(headersLower, client.contentLength))
-		{
-			printLog("🚨 Invalid Content-Length", RED);
-			client.status = 400;
-			client.keepAlive = false;
-			client.state = WRITING;
-			return;
-		}
+		client.status = 400;
+		client.keepAlive = false;
+		client.state = WRITING;
+		return;
 	}
+	//if is only chunked then decode 
+	if (hasTransferEncoding && isChunkedOnly)
+	{
+		decodeChunked(client, maxUploadSize);
+		return;
+	}
+
+	bool hasContentEncoding = headersLower.find("content-encoding:") != std::string::npos;
+	bool hasIdentityEncoding = hasHeaderToken(headersLower, "content-encoding:", "identity");
+	if (hasContentEncoding && !hasIdentityEncoding)
+	{
+		client.status = 415;
+		client.keepAlive = false;
+		client.state = WRITING;
+		return;
+	}
+
+	       // Always parse Content-Length from headers after receiving them.
+	       if (!parseContentLengthValue(headersLower, client.contentLength))
+	       {
+		       printLog("🚨 Invalid Content-Length", RED);
+		       client.status = 400;
+		       client.keepAlive = false;
+		       client.state = WRITING;
+		       return;
+	       }
 
 	// If declared body is larger than configured upload limit, fail early.
 	if (client.contentLength > maxUploadSize)

--- a/ServerManager/ServerManagerRequestRead.cpp
+++ b/ServerManager/ServerManagerRequestRead.cpp
@@ -208,7 +208,7 @@ void ServerManager::readClientRequest(ClientSession &client, size_t maxUploadSiz
 	// Build a lowercase view of the *header lines only* (exclude request line)
 	// so token scans cannot be spoofed via method/path/version text.
 	size_t requestLineEnd = client.readBuffer.find("\r\n");
-	if (requestLineEnd == std::string::npos || requestLineEnd >= headerEnd)
+	if (requestLineEnd == std::string::npos || requestLineEnd > headerEnd)
 	{
 		printLog("🚨 Malformed request line or headers", RED);
 		client.status = 400;

--- a/ServerManager/errors.txt
+++ b/ServerManager/errors.txt
@@ -1,0 +1,47 @@
+1. GET with very long URI | expected: 414 | got: 200
+
+Problem: No URI length check.
+Location: Request::parseRequestLine or Request::parseTargetAndQuery
+Fix: Add a check for URI length (e.g., if target.size() > 2048, set status 414).
+
+
+2. GET with multiple Host headers | expected: 400 | got: 200
+
+Problem: No check for duplicate Host headers.
+Location: Request::parseHeaders
+Fix: Count Host headers; if more than one, set status 400.
+
+
+3. GET with whitespace in method | expected: 400 | got: 200
+
+Problem: Method token not validated for whitespace.
+Location: Request::parseRequestLine
+Fix: Check if methodToken contains whitespace or is not a valid method.
+
+
+4. GET with tab in header name | expected: 400 | got: 200
+
+Problem: Header key not checked for tabs.
+Location: Request::parseHeaders
+Fix: Reject header keys containing tab ('\t').
+
+
+5. POST with chunked TE | expected: 200 | got:
+
+Problem: Chunked Transfer-Encoding not handled.
+Location: Request::parseAndValidateBody
+Fix: Implement chunked body parsing.
+
+
+6. GET with HTTP/1.0 and no Host | expected: 200 | got: 400
+
+Problem: Host header required for HTTP/1.0 (should not be).
+Location: Request::validateAndCacheHostHeader
+Fix: Only require Host for HTTP/1.1.
+
+
+7. GET with trailing whitespace | expected: 400 | got: 200
+
+Problem: Request-line not checked for trailing whitespace.
+Location: Request::parseRequestLine
+Fix: Reject request-lines with trailing whitespace.

--- a/config/ServerConfig.cpp
+++ b/config/ServerConfig.cpp
@@ -1,7 +1,7 @@
 #include "ServerConfig.hpp"
 
 ServerConfig::ServerConfig()
-: _fd(-1), _portDefined(false), _root("./www"), _rootDefined(false), _host("0.0.0.0")
+: _fd(-1), _portDefined(false), _root("www"), _rootDefined(false), _host("0.0.0.0")
 , _maxBodySize(1048576), _maxBodySizeFlag(false), _autoIndex(false), _autoIndexSet(false)
 , _absolutePath("")
 {

--- a/config/parser/ConfigParser.tpp
+++ b/config/parser/ConfigParser.tpp
@@ -144,6 +144,10 @@ void ConfigParser::parseRoot(T& object)
 		throw ConfigException("Error: There must be a valid path after 'root' keyword.");
 
 	ConfigUtils::validatePath(rootPath);
+
+	// Resolve relative paths using the server's absolute path (CWD)
+	if (rootPath[0] != '/')
+		rootPath = _absolutePath + rootPath;
 	object.setRoot(rootPath);
 	object.setRootFlag(true);
 

--- a/config/parser/ConfigUtils.cpp
+++ b/config/parser/ConfigUtils.cpp
@@ -90,9 +90,9 @@ void ConfigUtils::validateURL(std::string& url)
  */
 void ConfigUtils::validatePath(std::string& token)
 {
-	if (token[0] != '/')
+/* 	if (token[0] != '/')
 		throw ConfigException("Error: Invalid path format: " + token);
-
+ */
 	if (token.find("..") != std::string::npos)
 		throw ConfigException("Error: Invalid path format: " + token);
 	

--- a/config/parser/LocationParser.cpp
+++ b/config/parser/LocationParser.cpp
@@ -52,6 +52,11 @@ void ConfigParser::parseUploadStore(LocationConfig& location)
 		throw ConfigException("Error: Missing definitions after 'upload_store' keyword.");
 
 	ConfigUtils::checkIfDirectory(_tokens[_currentToken]);
+	std::string storePath = _tokens[_currentToken];
+	if (storePath[0] != '/')
+		storePath = _absolutePath + storePath;
+	location.setUploadStore(storePath);
+
 	//FALAR COM ELES E VERIFICAR AQUI SE DEVO SER EU A VERIFICAR SE O DIRETORIO EXISTE E
 	//SE TEM PERMISSAO DE EXECUCAO PARA A CRIACAO DE PASTAS
 	location.setUploadStore(_tokens[_currentToken]);
@@ -180,6 +185,9 @@ void ConfigParser::parseAlias(LocationConfig& location)
 		throw ConfigException("Error: Missing definition after 'alias' keyword.");
 
 	ConfigUtils::validatePath(token);
+	if (token[0] != '/')
+		token = _absolutePath + token;
+
 	location.setAlias(token);
 	location.setAliasFlag(true);
 

--- a/default.conf
+++ b/default.conf
@@ -1,5 +1,5 @@
 server {
-    root /home/mipinhei/Desktop/Common_Core/webserv_git/www;
+    root www;
     listen localhost:8080;
     listen localhost:8081;
     server_name example.com;
@@ -8,19 +8,19 @@ server {
     error_page 500 /errors/50x.html;
 
     location / {
-        root /home/mipinhei/Desktop/Common_Core/webserv_git/www;
+        root www;
         allow_methods GET POST DELETE;
         autoindex on;
     }
 
     location /upload {
         allow_methods POST DELETE GET;
-        upload_store /home/mipinhei/Desktop/Common_Core/webserv_git/www/uploads;
+        upload_store www/uploads;
     }
 
     location /cgi-bin {
         allow_methods GET POST;
-        alias /home/mipinhei/Desktop/Common_Core/webserv_git/www/cgi-bin;
+        alias www/cgi-bin;
         cgi_pass .py /usr/bin/python3;
         cgi_pass .php /usr/bin/php-cgi;
     }

--- a/default.conf
+++ b/default.conf
@@ -1,5 +1,5 @@
 server {
-    root /var/www/html;
+    root /www;
     listen localhost:8080;
     listen localhost:8081;
     server_name example.com;
@@ -7,22 +7,20 @@ server {
     error_page 404 /errors/404.html;
     error_page 500 /errors/50x.html;
 
-    location / {
-        root /var/www/html;
+     location / {
+        root /www;
         autoindex on;
         allow_methods GET POST DELETE;
-        autoindex off;
-        return 301 /new-path;
-    }
-
+    }    
+  
     location /upload {
         allow_methods POST DELETE;
-        upload_store /var/www/uploads;
+        upload_store /www/upload;
     }
 
     location /cgi-bin {
         allow_methods GET POST;
-        root /var/www/cgi-bin;
+        root /www/cgi-bin;
         cgi_pass .py /usr/bin/python3;
         cgi_pass .php /usr/bin/php-cgi;
     }

--- a/edge_tests.sh
+++ b/edge_tests.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+SERVER=localhost
+PORT=8080
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+function test_case() {
+    local name="$1"
+    local req="$2"
+    local expected="$3"
+    response=$(echo -e "$req" | nc -q 1 $SERVER $PORT)
+    status=$(echo "$response" | head -n 1)
+    if [[ "$status" == *"$expected"* ]]; then
+        PASS=$((PASS+1))
+    else
+        FAIL=$((FAIL+1))
+        FAILED_TESTS+=("$name | expected: $expected | got: $status")
+    fi
+}
+
+# Original tests
+test_case "Malformed Request Line" "BADREQUESTLINE\r\nHost: localhost\r\n\r\n" "400 Bad Request"
+test_case "Missing Host Header (HTTP/1.1)" "GET / HTTP/1.1\r\n\r\n" "400 Bad Request"
+test_case "Duplicate Content-Length" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nContent-Length: 10\r\n\r\nhello" "400 Bad Request"
+test_case "Unsupported Method" "PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n" "405 Method Not Allowed"
+test_case "Unsupported HTTP Version" "GET / HTTP/2.0\r\nHost: localhost\r\n\r\n" "505 HTTP Version Not Supported"
+test_case "Malformed Header Line" "GET / HTTP/1.1\r\nHost localhost\r\n\r\n" "400 Bad Request"
+test_case "Partial Request (Incomplete Body)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\nabc" ""
+test_case "Request Smuggling (CL + TE)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n" "400 Bad Request"
+test_case "Oversized Headers" "GET / HTTP/1.1\r\nHost: localhost\r\n$(printf 'X-Fill: %.0sA' {1..9000})\r\n\r\n" "431 Request Header Fields Too Large"
+test_case "Absolute URI in Request Line" "GET http://localhost:8080/ HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
+
+# Additional tests
+test_case "GET with Query String" "GET /index.html?foo=bar&baz=qux HTTP/1.1\r\nHost: localhost\r\n\r\n" "200 OK"
+test_case "POST with valid Content-Length" "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello" "200 OK"
+test_case "POST missing Content-Length" "POST /submit HTTP/1.1\r\nHost: localhost\r\n\r\nhello" "411 Length Required"
+test_case "POST with Content-Length 0" "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n" "200 OK"
+test_case "GET with extra headers" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Test: value\r\nX-Another: test\r\n\r\n" "200 OK"
+test_case "GET with Connection: keep-alive" "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n" "200 OK"
+test_case "GET with Connection: close" "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" "200 OK"
+test_case "GET with folded header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Folded: value\r\n another line\r\n\r\n" "400 Bad Request"
+test_case "GET with invalid UTF-8 in header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Bad: \xFF\xFE\r\n\r\n" "400 Bad Request"
+LONG_URI=$(printf '/%.0sA' {1..500})
+test_case "GET with very long URI" "GET $LONG_URI HTTP/1.1\r\nHost: localhost\r\n\r\n" "414 Request-URI Too Long"
+test_case "GET with multiple Host headers" "GET / HTTP/1.1\r\nHost: localhost\r\nHost: example.com\r\n\r\n" "400 Bad Request"
+test_case "GET with whitespace in method" "GET   / HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
+test_case "GET with tab in header name" "GET / HTTP/1.1\r\nHost:\tlocalhost\r\n\r\n" "400 Bad Request"
+test_case "GET with empty header value" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Empty:\r\n\r\n" "200 OK"
+test_case "POST with chunked TE" "POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n" "200 OK"
+test_case "GET with absolute path and port" "GET http://localhost:8080/index.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
+test_case "GET with HTTP/1.0 and keep-alive" "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n" "200 OK"
+test_case "GET with HTTP/1.0 and no Host" "GET / HTTP/1.0\r\n\r\n" "200 OK"
+test_case "GET with trailing whitespace" "GET /index.html HTTP/1.1   \r\nHost: localhost\r\n\r\n" "400 Bad Request"
+test_case "GET with invalid header (no colon)" "GET / HTTP/1.1\r\nHost: localhost\r\nInvalidHeader\r\n\r\n" "400 Bad Request"
+
+echo -e "\n=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ $FAIL -gt 0 ]; then
+    echo -e "\nFailed tests:"
+    for fail in "${FAILED_TESTS[@]}"; do
+        echo "- $fail"
+    done
+fi

--- a/edge_tests.sh
+++ b/edge_tests.sh
@@ -1,87 +1,494 @@
 #!/bin/bash
 
-SERVER=localhost
-PORT=8080
+SERVER=${1:-localhost}
+PORT=${2:-8080}
+UPLOAD_DIR="./www/uploads"
 
 PASS=0
 FAIL=0
+SKIP=0
 FAILED_TESTS=()
 
-function test_case() {
-    local name="$1"
-    local req="$2"
-    local expected="$3"
-    response=$(echo -e "$req" | nc -q 1 $SERVER $PORT)
-    status=$(echo "$response" | head -n 1)
-    if [[ "$status" == *"$expected"* ]]; then
-        PASS=$((PASS+1))
-    else
-        FAIL=$((FAIL+1))
-        FAILED_TESTS+=("$name | expected: $expected | got: $status")
-    fi
+# Colors
+RED='\033[0;31m'
+GRN='\033[0;32m'
+YEL='\033[1;33m'
+CYN='\033[0;36m'
+MAG='\033[0;35m'
+BLD='\033[1m'
+RST='\033[0m'
+
+# ─────────────────────────────────────────────
+# Core helpers
+# ─────────────────────────────────────────────
+
+# Send raw bytes via nc; waits up to 2 s for a response
+send_raw() {
+	printf "%b" "$1" | nc -q 2 "$SERVER" "$PORT" 2>/dev/null
 }
 
-# === Core Request Validation Tests ===
-test_case "Malformed Request Line" "BADREQUESTLINE\r\nHost: localhost\r\n\r\n" "400 Bad Request"
-test_case "Missing Host Header (HTTP/1.1)" "GET / HTTP/1.1\r\n\r\n" "400 Bad Request"
-test_case "Duplicate Content-Length" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nContent-Length: 10\r\n\r\nhello" "400 Bad Request"
-test_case "Request Smuggling (CL + TE)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n" "400 Bad Request"
-test_case "Unsupported Method" "PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n" "405 Method Not Allowed"
-test_case "Unsupported HTTP Version" "GET / HTTP/2.0\r\nHost: localhost\r\n\r\n" "505 HTTP Version Not Supported"
-test_case "Malformed Header Line" "GET / HTTP/1.1\r\nHost localhost\r\n\r\n" "400 Bad Request"
+# Extract first response line (status line)
+status_line() { echo "$1" | head -n 1; }
 
-# === Size Limit Tests ===
-test_case "Oversized Headers" "GET / HTTP/1.1\r\nHost: localhost\r\n$(printf 'X-Fill: %.0sA' {1..9000})\r\n\r\n" "431"
-LONG_URI=$(printf '/%.0sA' {1..2050})
-test_case "GET with very long URI" "GET $LONG_URI HTTP/1.1\r\nHost: localhost\r\n\r\n" "414 URI Too Long"
+# Extract a specific header value (case-insensitive name)
+get_header() {
+	local name
+	name=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+	echo "$2" | tr '[:upper:]' '[:lower:]' | grep "^${name}:" | head -n1 | cut -d: -f2- | tr -d '\r' | xargs
+}
 
-# === Malformed Request Tests ===
-test_case "Absolute URI in Request Line" "GET http://localhost:8080/ HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
-test_case "GET with whitespace in method" "GET   / HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
-test_case "GET with tab in header name" "GET / HTTP/1.1\r\nHost:\tlocalhost\r\n\r\n" "400 Bad Request"
-test_case "GET with folded header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Folded: value\r\n another line\r\n\r\n" "400 Bad Request"
-test_case "GET with invalid UTF-8 in header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Bad: \xFF\xFE\r\n\r\n" "400 Bad Request"
-test_case "GET with multiple Host headers" "GET / HTTP/1.1\r\nHost: localhost\r\nHost: example.com\r\n\r\n" "400 Bad Request"
-test_case "GET with trailing whitespace" "GET /index.html HTTP/1.1   \r\nHost: localhost\r\n\r\n" "400 Bad Request"
-test_case "GET with invalid header (no colon)" "GET / HTTP/1.1\r\nHost: localhost\r\nInvalidHeader\r\n\r\n" "400 Bad Request"
+# Check that response contains ALL expected substrings
+contains_all() {
+	local response="$1"; shift
+	for needle in "$@"; do
+		echo "$response" | grep -qF "$needle" || return 1
+	done
+	return 0
+}
 
-# === Partial/Incomplete Request Tests ===
-test_case "Partial Request (Incomplete Body)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\nabc" ""
+# ─────────────────────────────────────────────
+# Test runner functions
+# ─────────────────────────────────────────────
 
-# === Root Location (/) Tests ===
-test_case "GET with Query String" "GET /index.html?foo=bar&baz=qux HTTP/1.1\r\nHost: localhost\r\n\r\n" "200 OK"
-test_case "GET with extra headers" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Test: value\r\nX-Another: test\r\n\r\n" "200 OK"
-test_case "GET with Connection: keep-alive" "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n" "200 OK"
-test_case "GET with Connection: close" "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" "200 OK"
-test_case "GET with empty header value" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Empty:\r\n\r\n" "200 OK"
-test_case "GET with HTTP/1.0 and keep-alive" "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n" "200 OK"
-test_case "GET with HTTP/1.0 and no Host" "GET / HTTP/1.0\r\n\r\n" "200 OK"
+# test_status NAME RAW_REQUEST EXPECTED_STATUS_SUBSTR
+test_status() {
+	local name="$1" req="$2" expected="$3"
+	local response status
+	response=$(send_raw "$req")
+	status=$(status_line "$response")
+	if [[ "$status" == *"$expected"* ]]; then
+		echo -e "  ${GRN}✔${RST} $name"
+		PASS=$((PASS+1))
+	else
+		echo -e "  ${RED}✘${RST} $name"
+		echo -e "      ${YEL}expected:${RST} $expected"
+		echo -e "      ${YEL}got:${RST}      $status"
+		FAIL=$((FAIL+1))
+		FAILED_TESTS+=("$name")
+	fi
+}
 
-# === POST Tests (Root Location) ===
-test_case "POST with valid Content-Length" "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello" "200 OK"
-test_case "POST with Content-Length 0" "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n" "200 OK"
-test_case "POST missing Content-Length" "POST /submit HTTP/1.1\r\nHost: localhost\r\n\r\nhello" "411 Length Required"
-test_case "POST with chunked TE" "POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n" "200 OK"
+# test_status_and_header NAME RAW_REQUEST EXPECTED_STATUS HEADER_NAME HEADER_VALUE
+test_status_and_header() {
+	local name="$1" req="$2" exp_status="$3" hdr_name="$4" hdr_val="$5"
+	local response status hdr_found
+	response=$(send_raw "$req")
+	status=$(status_line "$response")
+	hdr_found=$(get_header "$hdr_name" "$response")
+	local ok=true
+	[[ "$status" != *"$exp_status"* ]] && ok=false
+	[[ "$hdr_found" != *"$hdr_val"* ]] && ok=false
+	if $ok; then
+		echo -e "  ${GRN}✔${RST} $name"
+		PASS=$((PASS+1))
+	else
+		echo -e "  ${RED}✘${RST} $name"
+		echo -e "      ${YEL}status expected:${RST} $exp_status  ${YEL}got:${RST} $status"
+		echo -e "      ${YEL}header $hdr_name expected:${RST} $hdr_val  ${YEL}got:${RST} $hdr_found"
+		FAIL=$((FAIL+1))
+		FAILED_TESTS+=("$name")
+	fi
+}
 
-# === Upload Location Tests (/upload - POST/DELETE only) ===
-test_case "POST to /upload" "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello" "200 OK"
-test_case "DELETE /upload" "DELETE /upload HTTP/1.1\r\nHost: localhost\r\n\r\n" "200 OK"
-test_case "GET to /upload (should fail - not allowed)" "GET /upload HTTP/1.1\r\nHost: localhost\r\n\r\n" "405 Method Not Allowed"
+# test_body NAME RAW_REQUEST EXPECTED_STATUS BODY_SUBSTR
+test_body() {
+	local name="$1" req="$2" exp_status="$3" body_substr="$4"
+	local response status body
+	response=$(send_raw "$req")
+	status=$(status_line "$response")
+	body=$(echo "$response" | awk 'found{print} /^\r?$/{found=1}')
+	if [[ "$status" == *"$exp_status"* ]] && echo "$body" | grep -qF "$body_substr"; then
+		echo -e "  ${GRN}✔${RST} $name"
+		PASS=$((PASS+1))
+	else
+		echo -e "  ${RED}✘${RST} $name"
+		echo -e "      ${YEL}status expected:${RST} $exp_status  ${YEL}got:${RST} $status"
+		echo -e "      ${YEL}body must contain:${RST} $body_substr"
+		FAIL=$((FAIL+1))
+		FAILED_TESTS+=("$name")
+	fi
+}
 
-# === CGI-BIN Location Tests (/cgi-bin - GET/POST only) ===
-test_case "GET to /cgi-bin" "GET /cgi-bin HTTP/1.1\r\nHost: localhost\r\n\r\n" "200"
-test_case "POST to /cgi-bin" "POST /cgi-bin HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n" "200"
-test_case "DELETE to /cgi-bin (should fail - not allowed)" "DELETE /cgi-bin HTTP/1.1\r\nHost: localhost\r\n\r\n" "405 Method Not Allowed"
+# test_no_response NAME RAW_REQUEST — expects connection to close with no complete HTTP response
+test_no_response() {
+	local name="$1" req="$2"
+	local response status
+	response=$(send_raw "$req")
+	status=$(status_line "$response")
+	if [[ -z "$status" || "$status" != HTTP* ]]; then
+		echo -e "  ${GRN}✔${RST} $name"
+		PASS=$((PASS+1))
+	else
+		echo -e "  ${RED}✘${RST} $name"
+		echo -e "      ${YEL}expected no complete HTTP response, got:${RST} $status"
+		FAIL=$((FAIL+1))
+		FAILED_TESTS+=("$name")
+	fi
+}
 
-# === Absolute URI Tests ===
-test_case "GET with absolute path and port" "GET http://localhost:8080/index.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
+section() { echo -e "\n${BLD}${CYN}━━━  $1  ━━━${RST}"; }
 
-echo -e "\n=== Summary ==="
-echo "Passed: $PASS"
-echo "Failed: $FAIL"
-if [ $FAIL -gt 0 ]; then
-    echo -e "\nFailed tests:"
-    for fail in "${FAILED_TESTS[@]}"; do
-        echo "- $fail"
-    done
+# ─────────────────────────────────────────────
+# SECTION 1 — Request line validation
+# ─────────────────────────────────────────────
+section "Request Line Validation"
+
+test_status "Malformed request line (no method/path/version)" \
+	"BADREQUESTLINE\r\nHost: localhost\r\n\r\n" "400"
+
+test_status "Missing HTTP version" \
+	"GET /\r\nHost: localhost\r\n\r\n" "400"
+
+test_status "Unsupported HTTP version (HTTP/2.0)" \
+	"GET / HTTP/2.0\r\nHost: localhost\r\n\r\n" "505"
+
+test_status "Unsupported HTTP version (HTTP/0.9)" \
+	"GET / HTTP/0.9\r\nHost: localhost\r\n\r\n" "505"
+
+test_status "Unknown method (PUT)" \
+	"PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n" "405"
+
+test_status "Unknown method (PATCH)" \
+	"PATCH / HTTP/1.1\r\nHost: localhost\r\n\r\n" "405"
+
+test_status "Unknown method (OPTIONS)" \
+	"OPTIONS / HTTP/1.1\r\nHost: localhost\r\n\r\n" "405"
+
+test_status "Very long URI (>2048 chars)" \
+	"GET /$(printf 'A%.0s' {1..2050}) HTTP/1.1\r\nHost: localhost\r\n\r\n" "414"
+
+test_status "Absolute URI in request line" \
+	"GET http://localhost:8080/ HTTP/1.1\r\nHost: localhost\r\n\r\n" "400"
+
+test_status "Extra whitespace in request line" \
+	"GET   / HTTP/1.1\r\nHost: localhost\r\n\r\n" "400"
+
+test_status "Trailing whitespace after version" \
+	"GET / HTTP/1.1   \r\nHost: localhost\r\n\r\n" "400"
+
+# ─────────────────────────────────────────────
+# SECTION 2 — Header validation
+# ─────────────────────────────────────────────
+section "Header Validation"
+
+test_status "Missing Host header (HTTP/1.1)" \
+	"GET / HTTP/1.1\r\n\r\n" "400"
+
+test_status "Multiple Host headers" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nHost: example.com\r\n\r\n" "400"
+
+test_status "Header without colon" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nInvalidHeader\r\n\r\n" "400"
+
+test_status "Folded header (obsolete RFC 7230)" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nX-Folded: value\r\n  continuation\r\n\r\n" "400"
+
+test_status "Tab in header name" \
+	"GET / HTTP/1.1\r\nHost:\tlocalhost\r\n\r\n" "400"
+
+test_status "Invalid UTF-8 byte in header value" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nX-Bad: \xff\xfe\r\n\r\n" "400"
+
+test_status "Oversized headers (>8192 bytes)" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\n$(python3 -c "print('X-Pad: ' + 'A'*8200)")\r\n\r\n" "431"
+
+# ─────────────────────────────────────────────
+# SECTION 3 — Body / Content-Length validation
+# ─────────────────────────────────────────────
+section "Body and Content-Length"
+
+test_status "Duplicate Content-Length headers" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nContent-Length: 10\r\n\r\nhello" "400"
+
+test_status "Content-Length + Transfer-Encoding (request smuggling)" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n" "400"
+
+test_status "Negative Content-Length" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: -1\r\n\r\n" "400"
+
+test_status "Non-numeric Content-Length" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: abc\r\n\r\n" "400"
+
+test_status "POST missing Content-Length" \
+	"POST /submit HTTP/1.1\r\nHost: localhost\r\n\r\nhello" "411"
+
+test_status "POST Content-Length 0 (valid)" \
+	"POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n" "200"
+
+test_no_response "Partial body (server waits, nc disconnects)" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 100\r\n\r\nonlya few bytes"
+
+# ─────────────────────────────────────────────
+# SECTION 4 — Transfer-Encoding: chunked
+# ─────────────────────────────────────────────
+section "Transfer-Encoding: chunked"
+
+test_status "Valid chunked POST" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n" "200"
+
+test_status "Chunked GET (unusual but valid)" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n" "200"
+
+test_status "Unsupported TE (gzip)" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: gzip\r\n\r\n" "501"
+
+test_status "Invalid chunk size (non-hex)" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\nZZZZ\r\nhello\r\n0\r\n\r\n" "400"
+
+test_status "Multiple Transfer-Encoding headers" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n" "400"
+
+test_status "Chunked with extensions (ignored)" \
+	"POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n5;ext=ignored\r\nhello\r\n0\r\n\r\n" "200"
+
+# ─────────────────────────────────────────────
+# SECTION 5 — GET / (root location)
+# ─────────────────────────────────────────────
+section "GET / (root location)"
+
+test_status "GET / basic" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n" "200"
+
+test_status "GET /index.html" \
+	"GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "200"
+
+test_status "GET with query string" \
+	"GET /index.html?foo=bar&baz=qux HTTP/1.1\r\nHost: localhost\r\n\r\n" "200"
+
+test_status "GET with extra headers" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nX-Custom: value\r\n\r\n" "200"
+
+test_status "GET with empty header value" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nX-Empty:\r\n\r\n" "200"
+
+test_status "GET nonexistent file" \
+	"GET /this_does_not_exist_xyz.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "404"
+
+test_status "GET path traversal attempt (../)" \
+	"GET /../etc/passwd HTTP/1.1\r\nHost: localhost\r\n\r\n" "400"
+
+test_status "GET path traversal encoded (%2e%2e)" \
+	"GET /%2e%2e/etc/passwd HTTP/1.1\r\nHost: localhost\r\n\r\n" "400"
+
+# ─────────────────────────────────────────────
+# SECTION 6 — HTTP version behaviours
+# ─────────────────────────────────────────────
+section "HTTP Version and Keep-Alive"
+
+test_status_and_header "HTTP/1.1 default keep-alive" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n" "200" "connection" "keep-alive"
+
+test_status_and_header "HTTP/1.1 Connection: close" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" "200" "connection" "close"
+
+test_status_and_header "HTTP/1.0 default close" \
+	"GET / HTTP/1.0\r\n\r\n" "200" "connection" "close"
+
+test_status_and_header "HTTP/1.0 Connection: keep-alive" \
+	"GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n" "200" "connection" "keep-alive"
+
+# ─────────────────────────────────────────────
+# SECTION 7 — HEAD method
+# ─────────────────────────────────────────────
+section "HEAD method"
+
+test_status "HEAD / returns 200 with no body" \
+	"HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n" "200"
+
+# HEAD response body must be empty; check Content-Length header still present
+_head_resp=$(send_raw "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+_head_body=$(echo "$_head_resp" | awk 'found{print} /^\r?$/{found=1}')
+if [[ -z "$(echo "$_head_body" | tr -d '\r\n ')" ]]; then
+	echo -e "  ${GRN}✔${RST} HEAD response has empty body"
+	PASS=$((PASS+1))
+else
+	echo -e "  ${RED}✘${RST} HEAD response must have empty body"
+	FAIL=$((FAIL+1))
+	FAILED_TESTS+=("HEAD response has empty body")
 fi
+unset _head_resp _head_body
+
+# ─────────────────────────────────────────────
+# SECTION 8 — Response headers
+# ─────────────────────────────────────────────
+section "Response Headers"
+
+_resp=$(send_raw "GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n")
+
+for _hdr in "content-type" "content-length" "date" "connection"; do
+	_val=$(get_header "$_hdr" "$_resp")
+	if [[ -n "$_val" ]]; then
+		echo -e "  ${GRN}✔${RST} Response includes '$_hdr' header"
+		PASS=$((PASS+1))
+	else
+		echo -e "  ${RED}✘${RST} Response missing '$_hdr' header"
+		FAIL=$((FAIL+1))
+		FAILED_TESTS+=("Response includes '$_hdr' header")
+	fi
+done
+unset _resp _hdr _val
+
+test_body "HTML file served with text/html content-type" \
+	"GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "200" ""
+# verify mime type separately
+_resp=$(send_raw "GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n")
+_ct=$(get_header "content-type" "$_resp")
+if [[ "$_ct" == *"text/html"* ]]; then
+	echo -e "  ${GRN}✔${RST} .html served as text/html"
+	PASS=$((PASS+1))
+else
+	echo -e "  ${RED}✘${RST} .html content-type expected text/html, got: $_ct"
+	FAIL=$((FAIL+1))
+	FAILED_TESTS+=(".html content-type")
+fi
+unset _resp _ct
+
+# ─────────────────────────────────────────────
+# SECTION 9 — /upload location
+# ─────────────────────────────────────────────
+section "/upload Location (POST/DELETE/GET)"
+
+test_status "GET /upload — method not allowed" \
+	"GET /upload HTTP/1.1\r\nHost: localhost\r\n\r\n" "405"
+
+# Raw body upload to /upload/<filename>
+test_status "POST raw body to /upload/test_raw.txt" \
+	"POST /upload/test_raw.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 13\r\n\r\nhello raw body" "201"
+
+# Re-upload the same file → should return 204 (no new file created)
+test_status "POST same file again → 204 (overwrite)" \
+	"POST /upload/test_raw.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 13\r\n\r\nhello raw body" "204"
+
+# Multipart upload
+_mp_boundary="TestBoundary42"
+_mp_body="--${_mp_boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"test_upload.txt\"\r\nContent-Type: text/plain\r\n\r\nMultipart content here\r\n--${_mp_boundary}--\r\n"
+_mp_len=$(printf "%b" "$_mp_body" | wc -c | tr -d ' ')
+test_status "POST multipart/form-data to /upload" \
+	"POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Type: multipart/form-data; boundary=${_mp_boundary}\r\nContent-Length: ${_mp_len}\r\n\r\n${_mp_body}" "201"
+unset _mp_boundary _mp_body _mp_len
+
+# POST to /upload without filename and without multipart → 400
+test_status "POST /upload with no filename and raw body → 400" \
+	"POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello" "400"
+
+# DELETE uploaded file
+test_status "DELETE /upload/test_raw.txt → 204" \
+	"DELETE /upload/test_raw.txt HTTP/1.1\r\nHost: localhost\r\n\r\n" "204"
+
+# DELETE nonexistent file
+test_status "DELETE /upload/nonexistent.txt → 404" \
+	"DELETE /upload/nonexistent.txt HTTP/1.1\r\nHost: localhost\r\n\r\n" "404"
+
+# DELETE with no filename → 400
+test_status "DELETE /upload (no filename) → 400" \
+	"DELETE /upload HTTP/1.1\r\nHost: localhost\r\n\r\n" "400"
+
+# Path traversal via upload filename
+test_status "POST /upload/../escape.txt → 400 or 403" \
+	"POST /upload/../escape.txt HTTP/1.1\r\nHost: localhost\r\nContent-Length: 3\r\n\r\nbad" "40"
+
+# ─────────────────────────────────────────────
+# SECTION 10 — /cgi-bin location
+# ─────────────────────────────────────────────
+section "/cgi-bin Location (GET/POST only)"
+
+test_status "GET /cgi-bin allowed" \
+	"GET /cgi-bin HTTP/1.1\r\nHost: localhost\r\n\r\n" "200"
+
+test_status "POST /cgi-bin allowed" \
+	"POST /cgi-bin HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n" "200"
+
+test_status "DELETE /cgi-bin — not allowed" \
+	"DELETE /cgi-bin HTTP/1.1\r\nHost: localhost\r\n\r\n" "405"
+
+# ─────────────────────────────────────────────
+# SECTION 11 — Autoindex
+# ─────────────────────────────────────────────
+section "Autoindex (directory listing)"
+
+_ai_resp=$(send_raw "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+_ai_status=$(status_line "$_ai_resp")
+if [[ "$_ai_status" == *"200"* ]]; then
+	# If autoindex is on and no index file, body should contain <ul> or directory listing HTML
+	_ai_body=$(echo "$_ai_resp" | awk 'found{print} /^\r?$/{found=1}')
+	if echo "$_ai_body" | grep -qiE '(<ul>|Index of|href)'; then
+		echo -e "  ${GRN}✔${RST} Autoindex returns directory listing HTML"
+		PASS=$((PASS+1))
+	else
+		echo -e "  ${YEL}~${RST} Autoindex: 200 returned but no listing HTML (index file probably served)"
+		SKIP=$((SKIP+1))
+	fi
+else
+	echo -e "  ${YEL}~${RST} Autoindex: unexpected status $_ai_status (check config)"
+	SKIP=$((SKIP+1))
+fi
+unset _ai_resp _ai_status _ai_body
+
+# Directory without trailing slash → 301 redirect
+test_status_and_header "Directory without trailing slash → 301 + Location" \
+	"GET /uploads HTTP/1.1\r\nHost: localhost\r\n\r\n" "301" "location" "/uploads/"
+
+# ─────────────────────────────────────────────
+# SECTION 12 — Error pages
+# ─────────────────────────────────────────────
+section "Error Pages"
+
+test_body "404 error page has HTML body" \
+	"GET /does_not_exist_abc123.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "404" "<html>"
+
+test_body "405 error page has HTML body" \
+	"PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n" "405" "<html>"
+
+# ─────────────────────────────────────────────
+# SECTION 13 — Security / path traversal
+# ─────────────────────────────────────────────
+section "Security"
+
+test_status "NULL byte in path" \
+	"GET /index%00.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "400"
+
+test_status "Double slash in path" \
+	"GET //etc/passwd HTTP/1.1\r\nHost: localhost\r\n\r\n" "400"
+
+test_status "GET /etc/passwd directly" \
+	"GET /etc/passwd HTTP/1.1\r\nHost: localhost\r\n\r\n" "404"
+
+# ─────────────────────────────────────────────
+# SECTION 14 — Pipelining (keep-alive)
+# ─────────────────────────────────────────────
+section "HTTP Pipelining (keep-alive)"
+
+# Send two requests in one TCP write; both should get responses
+_pipe_resp=$(printf "%b" \
+	"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n" \
+	"GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" \
+	| nc -q 3 "$SERVER" "$PORT" 2>/dev/null)
+
+_pipe_count=$(echo "$_pipe_resp" | grep -c "^HTTP/")
+if [[ "$_pipe_count" -ge 2 ]]; then
+	echo -e "  ${GRN}✔${RST} Pipelining: received $PASS_pipe_count responses for 2 pipelined requests"
+	PASS=$((PASS+1))
+else
+	echo -e "  ${RED}✘${RST} Pipelining: expected 2 HTTP responses, got $_pipe_count"
+	FAIL=$((FAIL+1))
+	FAILED_TESTS+=("Pipelining: 2 responses for 2 requests")
+fi
+unset _pipe_resp _pipe_count
+
+# ─────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────
+echo -e "\n${BLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+echo -e "  ${GRN}${BLD}Passed:${RST}  $PASS"
+echo -e "  ${RED}${BLD}Failed:${RST}  $FAIL"
+[[ $SKIP -gt 0 ]] && echo -e "  ${YEL}${BLD}Skipped:${RST} $SKIP"
+echo -e "${BLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RST}"
+
+if [[ $FAIL -gt 0 ]]; then
+	echo -e "\n${BLD}${RED}Failed tests:${RST}"
+	for t in "${FAILED_TESTS[@]}"; do
+		echo -e "  ${RED}•${RST} $t"
+	done
+	exit 1
+fi
+exit 0

--- a/edge_tests.sh
+++ b/edge_tests.sh
@@ -30,7 +30,9 @@ test_case "Unsupported HTTP Version" "GET / HTTP/2.0\r\nHost: localhost\r\n\r\n"
 test_case "Malformed Header Line" "GET / HTTP/1.1\r\nHost localhost\r\n\r\n" "400 Bad Request"
 test_case "Partial Request (Incomplete Body)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\nabc" ""
 test_case "Request Smuggling (CL + TE)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n" "400 Bad Request"
-test_case "Oversized Headers" "GET / HTTP/1.1\r\nHost: localhost\r\n$(printf 'X-Fill: %.0sA' {1..9000})\r\n\r\n" "431 Request Header Fields Too Large"
+test_case "Oversized Headers" "GET / HTTP/1.1\r\nHost: localhost\r\n$(printf 'X-Fill: %.0sA' {1..9000})\r\n\r\n" "431 "
+LONG_URI=$(printf '/%.0sA' {1..2050})
+test_case "GET with very long URI" "GET $LONG_URI HTTP/1.1\r\nHost: localhost\r\n\r\n" "414 URI Too Long"
 test_case "Absolute URI in Request Line" "GET http://localhost:8080/ HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
 
 # Additional tests
@@ -44,7 +46,7 @@ test_case "GET with Connection: close" "GET / HTTP/1.1\r\nHost: localhost\r\nCon
 test_case "GET with folded header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Folded: value\r\n another line\r\n\r\n" "400 Bad Request"
 test_case "GET with invalid UTF-8 in header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Bad: \xFF\xFE\r\n\r\n" "400 Bad Request"
 LONG_URI=$(printf '/%.0sA' {1..2050})
-test_case "GET with very long URI" "GET $LONG_URI HTTP/1.1\r\nHost: localhost\r\n\r\n" "414 Request-URI Too Long"
+test_case "GET with very long URI" "GET $LONG_URI HTTP/1.1\r\nHost: localhost\r\n\r\n" "414 URI Too Long"
 test_case "GET with multiple Host headers" "GET / HTTP/1.1\r\nHost: localhost\r\nHost: example.com\r\n\r\n" "400 Bad Request"
 test_case "GET with whitespace in method" "GET   / HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
 test_case "GET with tab in header name" "GET / HTTP/1.1\r\nHost:\tlocalhost\r\n\r\n" "400 Bad Request"

--- a/edge_tests.sh
+++ b/edge_tests.sh
@@ -43,7 +43,7 @@ test_case "GET with Connection: keep-alive" "GET / HTTP/1.1\r\nHost: localhost\r
 test_case "GET with Connection: close" "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" "200 OK"
 test_case "GET with folded header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Folded: value\r\n another line\r\n\r\n" "400 Bad Request"
 test_case "GET with invalid UTF-8 in header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Bad: \xFF\xFE\r\n\r\n" "400 Bad Request"
-LONG_URI=$(printf '/%.0sA' {1..500})
+LONG_URI=$(printf '/%.0sA' {1..2050})
 test_case "GET with very long URI" "GET $LONG_URI HTTP/1.1\r\nHost: localhost\r\n\r\n" "414 Request-URI Too Long"
 test_case "GET with multiple Host headers" "GET / HTTP/1.1\r\nHost: localhost\r\nHost: example.com\r\n\r\n" "400 Bad Request"
 test_case "GET with whitespace in method" "GET   / HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"

--- a/edge_tests.sh
+++ b/edge_tests.sh
@@ -21,42 +21,60 @@ function test_case() {
     fi
 }
 
-# Original tests
+# === Core Request Validation Tests ===
 test_case "Malformed Request Line" "BADREQUESTLINE\r\nHost: localhost\r\n\r\n" "400 Bad Request"
 test_case "Missing Host Header (HTTP/1.1)" "GET / HTTP/1.1\r\n\r\n" "400 Bad Request"
 test_case "Duplicate Content-Length" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nContent-Length: 10\r\n\r\nhello" "400 Bad Request"
+test_case "Request Smuggling (CL + TE)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n" "400 Bad Request"
 test_case "Unsupported Method" "PUT / HTTP/1.1\r\nHost: localhost\r\n\r\n" "405 Method Not Allowed"
 test_case "Unsupported HTTP Version" "GET / HTTP/2.0\r\nHost: localhost\r\n\r\n" "505 HTTP Version Not Supported"
 test_case "Malformed Header Line" "GET / HTTP/1.1\r\nHost localhost\r\n\r\n" "400 Bad Request"
-test_case "Partial Request (Incomplete Body)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\nabc" ""
-test_case "Request Smuggling (CL + TE)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n" "400 Bad Request"
-test_case "Oversized Headers" "GET / HTTP/1.1\r\nHost: localhost\r\n$(printf 'X-Fill: %.0sA' {1..9000})\r\n\r\n" "431 "
+
+# === Size Limit Tests ===
+test_case "Oversized Headers" "GET / HTTP/1.1\r\nHost: localhost\r\n$(printf 'X-Fill: %.0sA' {1..9000})\r\n\r\n" "431"
 LONG_URI=$(printf '/%.0sA' {1..2050})
 test_case "GET with very long URI" "GET $LONG_URI HTTP/1.1\r\nHost: localhost\r\n\r\n" "414 URI Too Long"
-test_case "Absolute URI in Request Line" "GET http://localhost:8080/ HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
 
-# Additional tests
+# === Malformed Request Tests ===
+test_case "Absolute URI in Request Line" "GET http://localhost:8080/ HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
+test_case "GET with whitespace in method" "GET   / HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
+test_case "GET with tab in header name" "GET / HTTP/1.1\r\nHost:\tlocalhost\r\n\r\n" "400 Bad Request"
+test_case "GET with folded header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Folded: value\r\n another line\r\n\r\n" "400 Bad Request"
+test_case "GET with invalid UTF-8 in header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Bad: \xFF\xFE\r\n\r\n" "400 Bad Request"
+test_case "GET with multiple Host headers" "GET / HTTP/1.1\r\nHost: localhost\r\nHost: example.com\r\n\r\n" "400 Bad Request"
+test_case "GET with trailing whitespace" "GET /index.html HTTP/1.1   \r\nHost: localhost\r\n\r\n" "400 Bad Request"
+test_case "GET with invalid header (no colon)" "GET / HTTP/1.1\r\nHost: localhost\r\nInvalidHeader\r\n\r\n" "400 Bad Request"
+
+# === Partial/Incomplete Request Tests ===
+test_case "Partial Request (Incomplete Body)" "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\nabc" ""
+
+# === Root Location (/) Tests ===
 test_case "GET with Query String" "GET /index.html?foo=bar&baz=qux HTTP/1.1\r\nHost: localhost\r\n\r\n" "200 OK"
-test_case "POST with valid Content-Length" "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello" "200 OK"
-test_case "POST missing Content-Length" "POST /submit HTTP/1.1\r\nHost: localhost\r\n\r\nhello" "411 Length Required"
-test_case "POST with Content-Length 0" "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n" "200 OK"
 test_case "GET with extra headers" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Test: value\r\nX-Another: test\r\n\r\n" "200 OK"
 test_case "GET with Connection: keep-alive" "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n" "200 OK"
 test_case "GET with Connection: close" "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" "200 OK"
-test_case "GET with folded header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Folded: value\r\n another line\r\n\r\n" "400 Bad Request"
-test_case "GET with invalid UTF-8 in header" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Bad: \xFF\xFE\r\n\r\n" "400 Bad Request"
-LONG_URI=$(printf '/%.0sA' {1..2050})
-test_case "GET with very long URI" "GET $LONG_URI HTTP/1.1\r\nHost: localhost\r\n\r\n" "414 URI Too Long"
-test_case "GET with multiple Host headers" "GET / HTTP/1.1\r\nHost: localhost\r\nHost: example.com\r\n\r\n" "400 Bad Request"
-test_case "GET with whitespace in method" "GET   / HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
-test_case "GET with tab in header name" "GET / HTTP/1.1\r\nHost:\tlocalhost\r\n\r\n" "400 Bad Request"
 test_case "GET with empty header value" "GET / HTTP/1.1\r\nHost: localhost\r\nX-Empty:\r\n\r\n" "200 OK"
-test_case "POST with chunked TE" "POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n" "200 OK"
-test_case "GET with absolute path and port" "GET http://localhost:8080/index.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
 test_case "GET with HTTP/1.0 and keep-alive" "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n" "200 OK"
 test_case "GET with HTTP/1.0 and no Host" "GET / HTTP/1.0\r\n\r\n" "200 OK"
-test_case "GET with trailing whitespace" "GET /index.html HTTP/1.1   \r\nHost: localhost\r\n\r\n" "400 Bad Request"
-test_case "GET with invalid header (no colon)" "GET / HTTP/1.1\r\nHost: localhost\r\nInvalidHeader\r\n\r\n" "400 Bad Request"
+
+# === POST Tests (Root Location) ===
+test_case "POST with valid Content-Length" "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello" "200 OK"
+test_case "POST with Content-Length 0" "POST /submit HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n" "200 OK"
+test_case "POST missing Content-Length" "POST /submit HTTP/1.1\r\nHost: localhost\r\n\r\nhello" "411 Length Required"
+test_case "POST with chunked TE" "POST / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n" "200 OK"
+
+# === Upload Location Tests (/upload - POST/DELETE only) ===
+test_case "POST to /upload" "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nhello" "200 OK"
+test_case "DELETE /upload" "DELETE /upload HTTP/1.1\r\nHost: localhost\r\n\r\n" "200 OK"
+test_case "GET to /upload (should fail - not allowed)" "GET /upload HTTP/1.1\r\nHost: localhost\r\n\r\n" "405 Method Not Allowed"
+
+# === CGI-BIN Location Tests (/cgi-bin - GET/POST only) ===
+test_case "GET to /cgi-bin" "GET /cgi-bin HTTP/1.1\r\nHost: localhost\r\n\r\n" "200"
+test_case "POST to /cgi-bin" "POST /cgi-bin HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n" "200"
+test_case "DELETE to /cgi-bin (should fail - not allowed)" "DELETE /cgi-bin HTTP/1.1\r\nHost: localhost\r\n\r\n" "405 Method Not Allowed"
+
+# === Absolute URI Tests ===
+test_case "GET with absolute path and port" "GET http://localhost:8080/index.html HTTP/1.1\r\nHost: localhost\r\n\r\n" "400 Bad Request"
 
 echo -e "\n=== Summary ==="
 echo "Passed: $PASS"

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>My First Heading</h1>
+<p>My first paragraph.</p>
+
+</body>
+</html>

--- a/www/uploads/test_upload.txt
+++ b/www/uploads/test_upload.txt
@@ -1,0 +1,1 @@
+Multipart content here


### PR DESCRIPTION
I ran the tester, and this is what we’ve got so far.

 
 ━━━  Request Line Validation  ━━━
  ✔ Malformed request line (no method/path/version)
  ✔ Missing HTTP version
  ✔ Unsupported HTTP version (HTTP/2.0)
  ✔ Unsupported HTTP version (HTTP/0.9)
  ✔ Unknown method (PUT)
  ✔ Unknown method (PATCH)
  ✔ Unknown method (OPTIONS)
  ✔ Very long URI (>2048 chars)
  ✔ Absolute URI in request line
  ✔ Extra whitespace in request line
  ✔ Trailing whitespace after version

━━━  Header Validation  ━━━
  ✔ Missing Host header (HTTP/1.1)
  ✔ Multiple Host headers
  ✔ Header without colon
  ✔ Folded header (obsolete RFC 7230)
  ✔ Tab in header name
  ✔ Invalid UTF-8 byte in header value
  ✔ Oversized headers (>8192 bytes)

━━━  Body and Content-Length  ━━━
  ✔ Duplicate Content-Length headers
  ✔ Content-Length + Transfer-Encoding (request smuggling)
  ✔ Negative Content-Length
  ✔ Non-numeric Content-Length
  ✔ POST missing Content-Length
  ✘ POST Content-Length 0 (valid)
      expected: 200
      got:      HTTP/1.1 501 Not Implemented
  ✔ Partial body (server waits, nc disconnects)

━━━  Transfer-Encoding: chunked  ━━━
  ✘ Valid chunked POST
      expected: 200
      got:      HTTP/1.1 501 Not Implemented
  ✔ Chunked GET (unusual but valid)
  ✔ Unsupported TE (gzip)
  ✔ Invalid chunk size (non-hex)
  ✔ Multiple Transfer-Encoding headers
  ✘ Chunked with extensions (ignored)
      expected: 200
      got:      HTTP/1.1 501 Not Implemented

━━━  GET / (root location)  ━━━
  ✔ GET / basic
  ✔ GET /index.html
  ✔ GET with query string
  ✔ GET with extra headers
  ✔ GET with empty header value
  ✔ GET nonexistent file
  ✘ GET path traversal attempt (../)
      expected: 400
      got:      HTTP/1.1 403 Forbidden
  ✘ GET path traversal encoded (%2e%2e)
      expected: 400
      got:      HTTP/1.1 404 Not Found

━━━  HTTP Version and Keep-Alive  ━━━
  ✔ HTTP/1.1 default keep-alive
  ✔ HTTP/1.1 Connection: close
  ✔ HTTP/1.0 default close
  ✔ HTTP/1.0 Connection: keep-alive

━━━  HEAD method  ━━━
  ✘ HEAD / returns 200 with no body
      expected: 200
      got:      HTTP/1.1 405 Method Not Allowed
  ✘ HEAD response must have empty body

━━━  Response Headers  ━━━
  ✔ Response includes 'content-type' header
  ✔ Response includes 'content-length' header
  ✔ Response includes 'date' header
  ✔ Response includes 'connection' header
  ✔ HTML file served with text/html content-type
  ✔ .html served as text/html

━━━  /upload Location (POST/DELETE/GET)  ━━━
  ✘ GET /upload — method not allowed
      expected: 405
      got:      HTTP/1.1 404 Not Found
  ✔ POST raw body to /upload/test_raw.txt
  ✔ POST same file again → 204 (overwrite)
  ✘ POST multipart/form-data to /upload
      expected: 201
      got:      HTTP/1.1 403 Forbidden
  ✔ POST /upload with no filename and raw body → 400
  ✔ DELETE /upload/test_raw.txt → 204
  ✔ DELETE /upload/nonexistent.txt → 404
  ✔ DELETE /upload (no filename) → 400
  ✔ POST /upload/../escape.txt → 400 or 403

━━━  /cgi-bin Location (GET/POST only)  ━━━
  ✘ GET /cgi-bin allowed
      expected: 200
      got:      HTTP/1.1 301 Moved Permanently
  ✘ POST /cgi-bin allowed
      expected: 200
      got:      HTTP/1.1 501 Not Implemented
  ✔ DELETE /cgi-bin — not allowed

━━━  Autoindex (directory listing)  ━━━
  ✔ Autoindex returns directory listing HTML
  ✔ Directory without trailing slash → 301 + Location

━━━  Error Pages  ━━━
  ✔ 404 error page has HTML body
  ✔ 405 error page has HTML body

━━━  Security  ━━━
  ✘ NULL byte in path
      expected: 400
      got:      HTTP/1.1 404 Not Found
  ✘ Double slash in path
      expected: 400
      got:      HTTP/1.1 404 Not Found
  ✔ GET /etc/passwd directly

━━━  HTTP Pipelining (keep-alive)  ━━━
  ✘ Pipelining: expected 2 HTTP responses, got 1

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Passed:  57
  Failed:  14
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Failed tests:
  • POST Content-Length 0 (valid)
  • Valid chunked POST
  • Chunked with extensions (ignored)
  • GET path traversal attempt (../)
  • GET path traversal encoded (%2e%2e)
  • HEAD / returns 200 with no body
  • HEAD response has empty body
  • GET /upload — method not allowed
  • POST multipart/form-data to /upload
  • GET /cgi-bin allowed
  • POST /cgi-bin allowed
  • NULL byte in path
  • Double slash in path
  • Pipelining: 2 responses for 2 requests
