### PR TITLE
reset startTime from cgi when reading

### DIFF
--- a/ServerManager/ServerManagerCgi.cpp
+++ b/ServerManager/ServerManagerCgi.cpp
@@ -148,6 +148,7 @@ void ServerManager::handleCgiRead(int clientFd, int serverIndex)
 		readBytes = read(client.cgi.readFd, buf, sizeof(buf));
 		if (readBytes > 0)
 			client.cgiOutputBuffer.append(buf, static_cast<size_t>(readBytes));
+			client.cgi.startTime = time(NULL);
 		else {
 			pipeEof = true;
 			break;


### PR DESCRIPTION
When the tester was running a POST method with 10000000, it was starting over, reseting. So I updated the startTime every time it appends to cgiOutputBuffer.